### PR TITLE
Adding Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: go
+
+go:
+  - 1.4.2
+  - tip
+
+matrix:
+  allow_failures:
+    - go: tip
+
+script:
+  - cd $HOME/gopath/src/collectd.org
+  - go vet -x ./...
+  - $HOME/gopath/bin/golint ./...
+  - go test -v ./...
+
+before_install:
+  - go get github.com/golang/lint/golint
+
+install:
+  - echo Skipping default TravisCI install step to handle canonical import paths...
+  - ln -s $HOME/gopath/src/github.com/ryancox/go-collectd $HOME/gopath/src/collectd.org 
+
+# notifications:
+#  irc: "chat.freenode.net#collectd"


### PR DESCRIPTION
Setup a travis CI job with this file to find broken builds, go vet and golint errors. 

Once you are happy with this, you can uncomment the last two lines to notify via IRC if build is broken

See: https://travis-ci.org/ryancox/go-collectd