### PR TITLE
go vet fixes

### DIFF
--- a/cdtime/cdtime_test.go
+++ b/cdtime/cdtime_test.go
@@ -24,7 +24,7 @@ func TestConversion(t *testing.T) {
 	for _, s := range cases {
 		want, err := time.Parse(time.RFC3339Nano, s)
 		if err != nil {
-			t.Errorf("time.Parse(%q): got (%v, %v), want (<time.Time>, nil)", want, err)
+			t.Errorf("time.Parse(%q): got (%v, %v), want (<time.Time>, nil)", s, want, err)
 			continue
 		}
 

--- a/format/graphite.go
+++ b/format/graphite.go
@@ -68,7 +68,7 @@ func (g *Graphite) formatValue(v api.Value) (string, error) {
 	case api.Gauge:
 		return fmt.Sprintf("%.15g", v), nil
 	case api.Derive, api.Counter:
-		return fmt.Sprintf("%d", v), nil
+		return fmt.Sprintf("%v", v), nil
 	default:
 		return "", fmt.Errorf("unexpected type %T", v)
 	}


### PR DESCRIPTION
Two fixes I noticed failing go vet on travis:
- cdtime_test.go: missing an argument in call to Errorf
- graphite.go: it looked legit to me. i think go vet was confused. changing to a `%v` is functional and satisfies go vet