### PR TITLE
Package api: Implement the TypesDB class.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2014 Kimo Rosenbaum
-Copyright (c) 2015 Florian Forster
+Copyright (c) 2014      Kimo Rosenbaum
+Copyright (c) 2015-2016 Florian Forster
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,236 @@
+// Package api defines data types representing core collectd data types.
+package api // import "collectd.org/api"
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrNoDataset is returned when the data set cannot be found.
+	ErrNoDataset = errors.New("no such dataset")
+)
+
+var (
+	dsTypeCounter = reflect.TypeOf(Counter(0))
+	dsTypeDerive  = reflect.TypeOf(Derive(0))
+	dsTypeGauge   = reflect.TypeOf(Gauge(0))
+)
+
+// TypesDB holds the type definitions of one or more types.db(5) files.
+type TypesDB struct {
+	rows map[string]*DataSet
+}
+
+// NewTypesDB parses collectd's types.db file and returns an initialized
+// TypesDB object that can be queried.
+func NewTypesDB(r io.Reader) (*TypesDB, error) {
+	db := &TypesDB{
+		rows: make(map[string]*DataSet),
+	}
+
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		line := s.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		ds, err := parseSet(s.Text())
+		if err != nil {
+			continue
+		}
+
+		db.rows[ds.Name] = ds
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+// Merge adds all entries in other to db, possibly overwriting entries in db
+// with the same name.
+func (db *TypesDB) Merge(other *TypesDB) {
+	for k, v := range other.rows {
+		db.rows[k] = v
+	}
+}
+
+// DataSet returns the DataSet "typ".
+// This is similar to collectd's plugin_get_ds() function.
+func (db *TypesDB) DataSet(typ string) (*DataSet, bool) {
+	s, ok := db.rows[typ]
+	return s, ok
+}
+
+// ValueList initializes and returns a new ValueList. The number of values
+// arguments must match the number of DataSources in the vl.Type DataSet and
+// are converted to []Value using DataSet.Values().
+func (db *TypesDB) ValueList(id Identifier, t time.Time, interval time.Duration, values ...interface{}) (*ValueList, error) {
+	ds, ok := db.DataSet(id.Type)
+	if !ok {
+		return nil, ErrNoDataset
+	}
+
+	v, err := ds.Values(values...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ValueList{
+		Identifier: id,
+		Time:       t,
+		Interval:   interval,
+		DSNames:    ds.Names(),
+		Values:     v,
+	}, nil
+}
+
+// DataSet defines the metrics of a given "Type", i.e. the name, kind (Derive,
+// Gauge, …) and minimum and maximum values.
+type DataSet struct {
+	Name    string
+	Sources []DataSource
+}
+
+func parseSet(line string) (*DataSet, error) {
+	ds := &DataSet{}
+
+	s := bufio.NewScanner(strings.NewReader(line))
+	s.Split(bufio.ScanWords)
+
+	for s.Scan() {
+		if ds.Name == "" {
+			ds.Name = s.Text()
+			continue
+		}
+
+		dsrc, err := parseSource(s.Text())
+		if err != nil {
+			return nil, err
+		}
+
+		ds.Sources = append(ds.Sources, *dsrc)
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}
+
+// Names returns a slice of the data source names. This can be used to populate ValueList.DSNames.
+func (ds *DataSet) Names() []string {
+	var ret []string
+	for _, dsrc := range ds.Sources {
+		ret = append(ret, dsrc.Name)
+	}
+
+	return ret
+}
+
+// Values converts the arguments to the Value interface type and returns them
+// as a slice. It expects the same number of arguments as it has Sources and
+// will return an error if there is a mismatch. Each argument is converted to a
+// Counter, Derive or Gauge according to the corresponding DataSource.Type.
+func (ds *DataSet) Values(args ...interface{}) ([]Value, error) {
+	if len(args) != len(ds.Sources) {
+		return nil, fmt.Errorf("len(args) = %d, want %d", len(args), len(ds.Sources))
+	}
+
+	var ret []Value
+	for i, arg := range args {
+		v, err := ds.Sources[i].Value(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, v)
+	}
+
+	return ret, nil
+}
+
+// DataSource defines one metric within a "Type" / DataSet. Type is one of
+// Counter, Derive and Gauge. Min and Max apply to the rates of Counter and
+// Derive types, not the raw incremental value.
+type DataSource struct {
+	Name     string
+	Type     reflect.Type
+	Min, Max float64
+}
+
+func parseSource(line string) (*DataSource, error) {
+	line = strings.TrimSuffix(line, ",")
+
+	f := strings.Split(line, ":")
+	if len(f) != 4 {
+		return nil, fmt.Errorf("unexpected field count: %d", len(f))
+	}
+
+	dsrc := &DataSource{
+		Name: f[0],
+		Min:  math.NaN(),
+		Max:  math.NaN(),
+	}
+
+	switch f[1] {
+	case "COUNTER":
+		dsrc.Type = dsTypeCounter
+	case "DERIVE":
+		dsrc.Type = dsTypeDerive
+	case "GAUGE":
+		dsrc.Type = dsTypeGauge
+	default:
+		return nil, fmt.Errorf("invalid data source type %q", f[1])
+	}
+
+	if f[2] != "U" {
+		v, err := strconv.ParseFloat(f[2], 64)
+		if err != nil {
+			return nil, err
+		}
+		dsrc.Min = v
+	}
+
+	if f[3] != "U" {
+		v, err := strconv.ParseFloat(f[3], 64)
+		if err != nil {
+			return nil, err
+		}
+		dsrc.Max = v
+	}
+
+	return dsrc, nil
+}
+
+// Value converts arg to a Counter, Derive or Gauge and returns it as the Value
+// interface type. Returns an error if arg cannot be converted.
+func (dsrc DataSource) Value(arg interface{}) (Value, error) {
+	if !reflect.TypeOf(arg).ConvertibleTo(dsrc.Type) {
+		return nil, fmt.Errorf("cannot convert %T to %s", arg, dsrc.Type.Name())
+	}
+
+	v := reflect.ValueOf(arg).Convert(dsrc.Type)
+	switch dsrc.Type {
+	case dsTypeCounter:
+		return v.Interface().(Counter), nil
+	case dsTypeDerive:
+		return v.Interface().(Derive), nil
+	case dsTypeGauge:
+		return v.Interface().(Gauge), nil
+	}
+
+	return nil, fmt.Errorf("unexpected data sourc type %s", dsrc.Type.Name())
+}

--- a/api/types.go
+++ b/api/types.go
@@ -162,6 +162,35 @@ func (ds *DataSet) Values(args ...interface{}) ([]Value, error) {
 	return ret, nil
 }
 
+// Check does sanity checking of vl and returns an error if it finds a problem.
+// Sanity checking includes checking the concrete types in the Values slice
+// against the DataSet's Sources.
+func (ds *DataSet) Check(vl *ValueList) error {
+	if ds.Name != vl.Type {
+		return fmt.Errorf("vl.Type = %q, want %q", vl.Type, ds.Name)
+	}
+
+	if len(ds.Sources) != len(vl.Values) {
+		return fmt.Errorf("len(vl.Values) = %d, want %d", len(vl.Values), len(ds.Sources))
+	}
+
+	if len(ds.Sources) != len(vl.DSNames) {
+		return fmt.Errorf("len(vl.DSNames) = %d, want %d", len(vl.DSNames), len(ds.Sources))
+	}
+
+	for i, dsrc := range ds.Sources {
+		if dsrc.Name != vl.DSNames[i] {
+			return fmt.Errorf("vl.DSNames[%d] = %q, want %q", i, vl.DSNames[i], dsrc.Name)
+		}
+
+		if reflect.TypeOf(vl.Values[i]) != dsrc.Type {
+			return fmt.Errorf("vl.Values[%d] is a %T, want %s", i, vl.Values[i], dsrc.Type.Name())
+		}
+	}
+
+	return nil
+}
+
 // DataSource defines one metric within a "Type" / DataSet. Type is one of
 // Counter, Derive and Gauge. Min and Max apply to the rates of Counter and
 // Derive types, not the raw incremental value.

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewTypesDB(t *testing.T) {
+	input := `
+percent			value:GAUGE:0:100.1
+total_bytes		value:DERIVE:0:U
+signal_noise		value:GAUGE:U:0
+mysql_qcache		hits:COUNTER:0:U, inserts:COUNTER:0:U, not_cached:COUNTER:0:U, lowmem_prunes:COUNTER:0:U, queries_in_cache:GAUGE:0:U
+`
+
+	db, err := NewTypesDB(strings.NewReader(input))
+	if err != nil {
+		t.Errorf("NewTypesDB() = %v, want %v", err, nil)
+	}
+
+	want := &DataSet{
+		Name: "percent",
+		Sources: []DataSource{
+			DataSource{
+				Name: "value",
+				Type: reflect.TypeOf(Gauge(0)),
+				Min:  0.0,
+				Max:  100.1,
+			},
+		},
+	}
+	got, ok := db.DataSet("percent")
+	if !ok || !reflect.DeepEqual(got, want) {
+		t.Errorf("db[%q] = %v, %v, want %v, %v", "percent", got, ok, want, true)
+	}
+
+	got, ok = db.DataSet("total_bytes")
+	if !ok {
+		t.Fatal(`db.DataSet("total_bytes") missing`)
+	}
+	if !math.IsNaN(got.Sources[0].Max) {
+		t.Errorf("got.Sources[0].Max = %g, want %g", got.Sources[0].Max, math.NaN())
+	}
+
+	got, ok = db.DataSet("signal_noise")
+	if !ok {
+		t.Fatal(`db.DataSet("signal_noise") missing`)
+	}
+	if !math.IsNaN(got.Sources[0].Min) {
+		t.Errorf("got.Sources[0].Min = %g, want %g", got.Sources[0].Min, math.NaN())
+	}
+
+	got, ok = db.DataSet("mysql_qcache")
+	if !ok {
+		t.Fatal(`db.DataSet("mysql_qcache") missing`)
+	}
+	if len(got.Sources) != 5 {
+		t.Errorf("len(got.Sources) = %d, want %d", len(got.Sources), 5)
+	}
+	for i, name := range []string{"hits", "inserts", "not_cached", "lowmem_prunes", "queries_in_cache"} {
+		if got.Sources[i].Name != name {
+			t.Errorf("got.Sources[%d].Name = %q, want %q", i, got.Sources[i].Name, name)
+		}
+	}
+}
+
+func TestTypesDB_ValueList(t *testing.T) {
+	db, err := NewTypesDB(strings.NewReader(`
+counter			value:COUNTER:U:U
+gauge			value:GAUGE:U:U
+derive			value:DERIVE:0:U
+if_octets		rx:DERIVE:0:U, tx:DERIVE:0:U
+	`))
+	if err != nil {
+		t.Errorf("NewTypesDB() = %v, want %v", err, nil)
+	}
+
+	id := Identifier{
+		Host:   "example.com",
+		Plugin: "golang",
+		Type:   "gauge",
+	}
+	vl, err := db.ValueList(id, time.Unix(1469175855, 0), 10*time.Second, Gauge(42))
+	if err != nil {
+		t.Errorf("db.Values(%v, %v, %v, %v) = (%v, %v), want (..., %v)", id, time.Unix(1469175855, 0), 10*time.Second, Gauge(42.0), vl, err, nil)
+	}
+
+}
+
+func TestDataSource_Value(t *testing.T) {
+	cases := []struct {
+		arg       interface{}
+		typ       reflect.Type
+		wantValue Value
+		wantErr   bool
+	}{
+		// COUNTER
+		{int(42), dsTypeCounter, Counter(42), false},
+		{uint(42), dsTypeCounter, Counter(42), false},
+		{int64(42), dsTypeCounter, Counter(42), false},
+		{uint64(42), dsTypeCounter, Counter(42), false},
+		{float32(42.5), dsTypeCounter, Counter(42), false},
+		{float64(42.8), dsTypeCounter, Counter(42), false},
+		{Counter(42), dsTypeCounter, Counter(42), false},
+		{true, dsTypeCounter, nil, true},
+		{"42", dsTypeCounter, nil, true},
+		// DERIVE
+		{int(42), dsTypeDerive, Derive(42), false},
+		{uint(42), dsTypeDerive, Derive(42), false},
+		{int64(42), dsTypeDerive, Derive(42), false},
+		{uint64(42), dsTypeDerive, Derive(42), false},
+		{float32(42.5), dsTypeDerive, Derive(42), false},
+		{float64(42.8), dsTypeDerive, Derive(42), false},
+		{Derive(42), dsTypeDerive, Derive(42), false},
+		{true, dsTypeDerive, nil, true},
+		{"42", dsTypeDerive, nil, true},
+		// GAUGE
+		{int(42), dsTypeGauge, Gauge(42), false},
+		{uint(42), dsTypeGauge, Gauge(42), false},
+		{int64(42), dsTypeGauge, Gauge(42), false},
+		{uint64(42), dsTypeGauge, Gauge(42), false},
+		{float32(42.5), dsTypeGauge, Gauge(42.5), false},
+		{float64(42.8), dsTypeGauge, Gauge(42.8), false},
+		{Gauge(42.9), dsTypeGauge, Gauge(42.9), false},
+		{true, dsTypeGauge, nil, true},
+		{"42", dsTypeGauge, nil, true},
+	}
+
+	for _, c := range cases {
+		dsrc := DataSource{
+			Name: "value",
+			Type: c.typ,
+			Min:  0.0,
+			Max:  math.NaN(),
+		}
+
+		got, err := dsrc.Value(c.arg)
+		if err != nil {
+			if !c.wantErr {
+				t.Errorf("dsrc.Type = %s; dsrc.Value(%v) = (%v, %v), want <err>", dsrc.Type.Name(), c.arg, got, err)
+			}
+			continue
+		}
+
+		if c.wantErr || !reflect.DeepEqual(got, c.wantValue) {
+			var wantErr error
+			if c.wantErr {
+				wantErr = errors.New("<err>")
+			}
+
+			t.Errorf("dsrc.Type = %s; dsrc.Value(%v) = (%v, %v), want (%v, %v)", dsrc.Type.Name(), c.arg, got, err, c.wantValue, wantErr)
+		}
+	}
+}

--- a/network/buffer.go
+++ b/network/buffer.go
@@ -77,6 +77,21 @@ func (b *Buffer) Available() int {
 	return b.size - unavail
 }
 
+// Bytes returns the content of the buffer as a byte slice.
+// If signing or encrypting are enabled, the content will be signed / encrypted
+// prior to being returned.
+// This method resets the buffer.
+func (b *Buffer) Bytes() ([]byte, error) {
+	tmp := make([]byte, b.size)
+
+	n, err := b.Read(tmp)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmp[:n], nil
+}
+
 // Read reads the buffer into "out". If signing or encryption is enabled, data
 // will be signed / encrypted before writing it to "out". Returns
 // ErrNotEnoughSpace if the provided buffer is too small to hold the entire

--- a/network/server.go
+++ b/network/server.go
@@ -26,7 +26,8 @@ type Server struct {
 	Writer         api.Writer     // Object used to send incoming ValueLists to.
 	BufferSize     uint16         // Maximum packet size to accept.
 	PasswordLookup PasswordLookup // User to password lookup.
-	SecurityLevel  SecurityLevel  // Minimal required security level
+	SecurityLevel  SecurityLevel  // Minimal required security level.
+	TypesDB        *api.TypesDB   // TypesDB for looking up DS names and verify data source types.
 	// Interface is the name of the interface to use when subscribing to a
 	// multicast group. Has no effect when using unicast.
 	Interface string
@@ -70,6 +71,7 @@ func (srv *Server) ListenAndWrite() error {
 	popts := ParseOpts{
 		PasswordLookup: srv.PasswordLookup,
 		SecurityLevel:  srv.SecurityLevel,
+		TypesDB:        srv.TypesDB,
 	}
 
 	for {


### PR DESCRIPTION
This patch adds support for reading collectd's *types.db(5)* files and creating *ValueList* types based on these definitions. It also adds support to the *network* package so that the *[]ValueList* returned by *Parse()* have the *DSNames* field set.

Values may also be cast to the correct "data source type". This is similar to the way *collectd* behaves, though collectd will simply access the wrong type of a union, without a cast, causing quite erratic behavior.

Fixes: #13 