### PR TITLE
All packages: API changes

### DIFF
--- a/api/json.go
+++ b/api/json.go
@@ -23,7 +23,7 @@ type jsonValueList struct {
 
 // MarshalJSON implements the "encoding/json".Marshaler interface for
 // ValueList.
-func (vl ValueList) MarshalJSON() ([]byte, error) {
+func (vl *ValueList) MarshalJSON() ([]byte, error) {
 	jvl := jsonValueList{
 		Values:         make([]json.Number, len(vl.Values)),
 		DSTypes:        make([]string, len(vl.Values)),

--- a/api/json_test.go
+++ b/api/json_test.go
@@ -61,7 +61,7 @@ func ExampleValueList_UnmarshalJSON() {
 
 		for _, vl := range vls {
 			var w Writer
-			w.Write(vl)
+			w.Write(r.Context(), vl)
 			// "w" is a placeholder to avoid cyclic dependencies.
 			// In real live, you'd do something like this here:
 			// exec.Putval.Write(vl)

--- a/api/json_test.go
+++ b/api/json_test.go
@@ -52,7 +52,7 @@ func ExampleValueList_UnmarshalJSON() {
 			return
 		}
 
-		var vls []ValueList
+		var vls []*ValueList
 		if err := json.Unmarshal(data, &vls); err != nil {
 			log.Printf("while parsing JSON: %v", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/api/main.go
+++ b/api/main.go
@@ -89,7 +89,7 @@ type ValueList struct {
 // DSName returns the name of the data source at the given index. If vl.DSNames
 // is nil, returns "value" if there is a single value and a string
 // representation of index otherwise.
-func (vl ValueList) DSName(index int) string {
+func (vl *ValueList) DSName(index int) string {
 	if vl.DSNames != nil {
 		return vl.DSNames[index]
 	} else if len(vl.Values) != 1 {
@@ -102,7 +102,7 @@ func (vl ValueList) DSName(index int) string {
 // Writer are objects accepting a ValueList for writing, for example to the
 // network.
 type Writer interface {
-	Write(vl ValueList) error
+	Write(vl *ValueList) error
 }
 
 // String returns a string representation of the Identifier.
@@ -137,7 +137,7 @@ func (d *Dispatcher) Len() int {
 // Write starts a new Goroutine for each Writer which creates a copy of the
 // ValueList and then calls the Writer with the copy. It returns nil
 // immediately.
-func (d *Dispatcher) Write(vl ValueList) error {
+func (d *Dispatcher) Write(vl *ValueList) error {
 	for _, w := range d.writers {
 		go func(w Writer) {
 			vlCopy := vl

--- a/api/main.go
+++ b/api/main.go
@@ -2,6 +2,7 @@
 package api // import "collectd.org/api"
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -102,7 +103,7 @@ func (vl *ValueList) DSName(index int) string {
 // Writer are objects accepting a ValueList for writing, for example to the
 // network.
 type Writer interface {
-	Write(vl *ValueList) error
+	Write(context.Context, *ValueList) error
 }
 
 // String returns a string representation of the Identifier.
@@ -137,14 +138,14 @@ func (d *Dispatcher) Len() int {
 // Write starts a new Goroutine for each Writer which creates a copy of the
 // ValueList and then calls the Writer with the copy. It returns nil
 // immediately.
-func (d *Dispatcher) Write(vl *ValueList) error {
+func (d *Dispatcher) Write(ctx context.Context, vl *ValueList) error {
 	for _, w := range d.writers {
 		go func(w Writer) {
 			vlCopy := vl
 			vlCopy.Values = make([]Value, len(vl.Values))
 			copy(vlCopy.Values, vl.Values)
 
-			if err := w.Write(vlCopy); err != nil {
+			if err := w.Write(ctx, vlCopy); err != nil {
 				log.Printf("%T.Write(): %v", w, err)
 			}
 		}(w)

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -18,7 +18,7 @@ var Putval = format.NewPutval(os.Stdout)
 
 type valueCallback struct {
 	callback func() api.Value
-	vl       api.ValueList
+	vl       *api.ValueList
 	done     chan bool
 }
 
@@ -49,7 +49,7 @@ func NewExecutor() *Executor {
 // ValueCallback adds a simple "value" callback to the Executor. The callback
 // only returns a Number, i.e. either a api.Gauge or api.Derive, and formatting
 // and printing is done by the executor.
-func (e *Executor) ValueCallback(callback func() api.Value, vl api.ValueList) {
+func (e *Executor) ValueCallback(callback func() api.Value, vl *api.ValueList) {
 	e.cb = append(e.cb, valueCallback{
 		callback: callback,
 		vl:       vl,

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -3,6 +3,7 @@
 package exec // import "collectd.org/exec"
 
 import (
+	"context"
 	"log"
 	"os"
 	"strconv"
@@ -23,13 +24,13 @@ type valueCallback struct {
 }
 
 type voidCallback struct {
-	callback func(time.Duration)
+	callback func(context.Context, time.Duration)
 	interval time.Duration
 	done     chan bool
 }
 
 type callback interface {
-	run(*sync.WaitGroup)
+	run(context.Context, *sync.WaitGroup)
 	stop()
 }
 
@@ -62,7 +63,7 @@ func (e *Executor) ValueCallback(callback func() api.Value, vl *api.ValueList) {
 // callback needs to format and print the appropriate lines to "STDOUT".
 // However, this allows cases in which the number of values reported varies,
 // e.g. depending on the system the code is running on.
-func (e *Executor) VoidCallback(callback func(time.Duration), interval time.Duration) {
+func (e *Executor) VoidCallback(callback func(context.Context, time.Duration), interval time.Duration) {
 	e.cb = append(e.cb, voidCallback{
 		callback: callback,
 		interval: interval,
@@ -71,10 +72,10 @@ func (e *Executor) VoidCallback(callback func(time.Duration), interval time.Dura
 }
 
 // Run starts calling all callbacks periodically and blocks.
-func (e *Executor) Run() {
+func (e *Executor) Run(ctx context.Context) {
 	for _, cb := range e.cb {
 		e.group.Add(1)
-		go cb.run(&e.group)
+		go cb.run(ctx, &e.group)
 	}
 
 	e.group.Wait()
@@ -88,7 +89,7 @@ func (e *Executor) Stop() {
 	}
 }
 
-func (cb valueCallback) run(g *sync.WaitGroup) {
+func (cb valueCallback) run(ctx context.Context, g *sync.WaitGroup) {
 	if cb.vl.Host == "" {
 		cb.vl.Host = Hostname()
 	}
@@ -102,7 +103,7 @@ func (cb valueCallback) run(g *sync.WaitGroup) {
 		case _ = <-ticker.C:
 			cb.vl.Values[0] = cb.callback()
 			cb.vl.Time = time.Now()
-			Putval.Write(cb.vl)
+			Putval.Write(ctx, cb.vl)
 		case _ = <-cb.done:
 			g.Done()
 			return
@@ -114,13 +115,13 @@ func (cb valueCallback) stop() {
 	cb.done <- true
 }
 
-func (cb voidCallback) run(g *sync.WaitGroup) {
+func (cb voidCallback) run(ctx context.Context, g *sync.WaitGroup) {
 	ticker := time.NewTicker(sanitizeInterval(cb.interval))
 
 	for {
 		select {
 		case _ = <-ticker.C:
-			cb.callback(cb.interval)
+			cb.callback(ctx, cb.interval)
 		case _ = <-cb.done:
 			g.Done()
 			return

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -45,7 +45,7 @@ func Example() {
 	answer := func() api.Value {
 		return api.Gauge(42)
 	}
-	e.ValueCallback(answer, api.ValueList{
+	e.ValueCallback(answer, &api.ValueList{
 		Identifier: api.Identifier{
 			Host:         "example.com",
 			Plugin:       "golang",
@@ -57,7 +57,7 @@ func Example() {
 
 	// "complex" void callback
 	bicycles := func(interval time.Duration) {
-		vl := api.ValueList{
+		vl := &api.ValueList{
 			Identifier: api.Identifier{
 				Host:   "example.com",
 				Plugin: "golang",

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -1,6 +1,7 @@
 package exec // import "collectd.org/exec"
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -56,7 +57,7 @@ func Example() {
 	})
 
 	// "complex" void callback
-	bicycles := func(interval time.Duration) {
+	bicycles := func(ctx context.Context, interval time.Duration) {
 		vl := &api.ValueList{
 			Identifier: api.Identifier{
 				Host:   "example.com",
@@ -77,11 +78,11 @@ func Example() {
 		for _, d := range data {
 			vl.Values[0] = d.Value
 			vl.Identifier.TypeInstance = d.TypeInstance
-			Putval.Write(vl)
+			Putval.Write(ctx, vl)
 		}
 	}
 	e.VoidCallback(bicycles, time.Second)
 
 	// blocks forever
-	e.Run()
+	e.Run(context.Background())
 }

--- a/export/export.go
+++ b/export/export.go
@@ -40,6 +40,7 @@ Gauge.
 package export // import "collectd.org/export"
 
 import (
+	"context"
 	"expvar"
 	"log"
 	"math"
@@ -75,7 +76,7 @@ type Options struct {
 
 // Run periodically calls the ValueList function of each Var, sets the Time and
 // Interval fields and passes it w.Write(). This function blocks indefinitely.
-func Run(w api.Writer, opts Options) error {
+func Run(ctx context.Context, w api.Writer, opts Options) error {
 	ticker := time.NewTicker(opts.Interval)
 
 	for {
@@ -86,7 +87,7 @@ func Run(w api.Writer, opts Options) error {
 				vl := v.ValueList()
 				vl.Time = time.Now()
 				vl.Interval = opts.Interval
-				if err := w.Write(vl); err != nil {
+				if err := w.Write(ctx, vl); err != nil {
 					mutex.RUnlock()
 					return err
 				}

--- a/export/export.go
+++ b/export/export.go
@@ -57,7 +57,7 @@ var (
 
 // Var is an abstract type for metrics exported by this package.
 type Var interface {
-	ValueList() api.ValueList
+	ValueList() *api.ValueList
 }
 
 // Publish adds v to the internal list of exported metrics.
@@ -145,10 +145,10 @@ func (d *Derive) String() string {
 
 // ValueList returns the ValueList representation of d. Both, Time and Interval
 // are set to zero.
-func (d *Derive) ValueList() api.ValueList {
+func (d *Derive) ValueList() *api.ValueList {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	return api.ValueList{
+	return &api.ValueList{
 		Identifier: d.id,
 		Values:     []api.Value{d.value},
 	}
@@ -202,10 +202,10 @@ func (g *Gauge) String() string {
 
 // ValueList returns the ValueList representation of g. Both, Time and Interval
 // are set to zero.
-func (g *Gauge) ValueList() api.ValueList {
+func (g *Gauge) ValueList() *api.ValueList {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
-	return api.ValueList{
+	return &api.ValueList{
 		Identifier: g.id,
 		Values:     []api.Value{g.value},
 	}

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -19,7 +19,7 @@ func TestDerive(t *testing.T) {
 		d.Add(i)
 	}
 
-	want := api.ValueList{
+	want := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:   "example.com",
 			Plugin: "golang",
@@ -48,7 +48,7 @@ func TestGauge(t *testing.T) {
 
 	g.Set(42.0)
 
-	want := api.ValueList{
+	want := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:   "example.com",
 			Plugin: "golang",

--- a/format/graphite.go
+++ b/format/graphite.go
@@ -76,7 +76,7 @@ func (g *Graphite) formatValue(v api.Value) (string, error) {
 
 // Write formats the ValueList in the PUTVAL format and writes it to the
 // assiciated io.Writer.
-func (g *Graphite) Write(vl api.ValueList) error {
+func (g *Graphite) Write(vl *api.ValueList) error {
 	for i, v := range vl.Values {
 		dsName := ""
 		if g.AlwaysAppendDS || len(vl.Values) != 1 {

--- a/format/graphite.go
+++ b/format/graphite.go
@@ -1,6 +1,7 @@
 package format // import "collectd.org/format"
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -76,7 +77,7 @@ func (g *Graphite) formatValue(v api.Value) (string, error) {
 
 // Write formats the ValueList in the PUTVAL format and writes it to the
 // assiciated io.Writer.
-func (g *Graphite) Write(vl *api.ValueList) error {
+func (g *Graphite) Write(_ context.Context, vl *api.ValueList) error {
 	for i, v := range vl.Values {
 		dsName := ""
 		if g.AlwaysAppendDS || len(vl.Values) != 1 {

--- a/format/graphite_test.go
+++ b/format/graphite_test.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -9,6 +10,8 @@ import (
 )
 
 func TestWrite(t *testing.T) {
+	ctx := context.Background()
+
 	cases := []struct {
 		ValueList *api.ValueList
 		Graphite  *Graphite
@@ -85,7 +88,7 @@ func TestWrite(t *testing.T) {
 		buf := &bytes.Buffer{}
 		c.Graphite.W = buf
 
-		if err := c.Graphite.Write(c.ValueList); err != nil {
+		if err := c.Graphite.Write(ctx, c.ValueList); err != nil {
 			t.Errorf("case %d: got %v, want %v", i, err, nil)
 		}
 

--- a/format/graphite_test.go
+++ b/format/graphite_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestWrite(t *testing.T) {
 	cases := []struct {
-		ValueList api.ValueList
+		ValueList *api.ValueList
 		Graphite  *Graphite
 		Want      string
 	}{
 		{ // case 0
-			ValueList: api.ValueList{
+			ValueList: &api.ValueList{
 				Identifier: api.Identifier{
 					Host:           "example.com",
 					Plugin:         "golang",
@@ -37,7 +37,7 @@ func TestWrite(t *testing.T) {
 			Want: "-->example_com<--.golang-example.gauge-answer.value 42 1426975989\r\n",
 		},
 		{ // case 1
-			ValueList: api.ValueList{
+			ValueList: &api.ValueList{
 				Identifier: api.Identifier{
 					Host:           "example.com",
 					Plugin:         "golang",
@@ -59,7 +59,7 @@ func TestWrite(t *testing.T) {
 			Want: "collectd.example@com.golang.example.gauge.answer 1337 1426975989\r\n",
 		},
 		{ // case 2
-			ValueList: api.ValueList{
+			ValueList: &api.ValueList{
 				Identifier: api.Identifier{
 					Host:   "example.com",
 					Plugin: "golang",

--- a/format/putval.go
+++ b/format/putval.go
@@ -25,7 +25,7 @@ func NewPutval(w io.Writer) *Putval {
 
 // Write formats the ValueList in the PUTVAL format and writes it to the
 // assiciated io.Writer.
-func (p *Putval) Write(vl api.ValueList) error {
+func (p *Putval) Write(vl *api.ValueList) error {
 	s, err := formatValues(vl)
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func (p *Putval) Write(vl api.ValueList) error {
 	return err
 }
 
-func formatValues(vl api.ValueList) (string, error) {
+func formatValues(vl *api.ValueList) (string, error) {
 	fields := make([]string, 1+len(vl.Values))
 
 	fields[0] = formatTime(vl.Time)

--- a/format/putval.go
+++ b/format/putval.go
@@ -3,6 +3,7 @@
 package format // import "collectd.org/format"
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -25,7 +26,7 @@ func NewPutval(w io.Writer) *Putval {
 
 // Write formats the ValueList in the PUTVAL format and writes it to the
 // assiciated io.Writer.
-func (p *Putval) Write(vl *api.ValueList) error {
+func (p *Putval) Write(_ context.Context, vl *api.ValueList) error {
 	s, err := formatValues(vl)
 	if err != nil {
 		return err

--- a/network/buffer.go
+++ b/network/buffer.go
@@ -159,7 +159,7 @@ func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
 // Write adds a ValueList to the buffer. Returns ErrNotEnoughSpace if not
 // enough space in the buffer is available to add this value list. In that
 // case, call Read() to empty the buffer and try again.
-func (b *Buffer) Write(vl api.ValueList) error {
+func (b *Buffer) Write(vl *api.ValueList) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -176,7 +176,7 @@ func (b *Buffer) Write(vl api.ValueList) error {
 	return nil
 }
 
-func (b *Buffer) writeValueList(vl api.ValueList) error {
+func (b *Buffer) writeValueList(vl *api.ValueList) error {
 	if err := b.writeIdentifier(vl.Identifier); err != nil {
 		return err
 	}

--- a/network/buffer.go
+++ b/network/buffer.go
@@ -2,6 +2,7 @@ package network // import "collectd.org/network"
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -159,7 +160,7 @@ func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
 // Write adds a ValueList to the buffer. Returns ErrNotEnoughSpace if not
 // enough space in the buffer is available to add this value list. In that
 // case, call Read() to empty the buffer and try again.
-func (b *Buffer) Write(vl *api.ValueList) error {
+func (b *Buffer) Write(_ context.Context, vl *api.ValueList) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 

--- a/network/buffer_test.go
+++ b/network/buffer_test.go
@@ -13,7 +13,7 @@ import (
 func TestWriteValueList(t *testing.T) {
 	b := NewBuffer(0)
 
-	vl := api.ValueList{
+	vl := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:   "example.com",
 			Plugin: "golang",
@@ -30,7 +30,7 @@ func TestWriteValueList(t *testing.T) {
 	}
 
 	// ValueList with much the same fields, to test compression.
-	vl = api.ValueList{
+	vl = &api.ValueList{
 		Identifier: api.Identifier{
 			Host:           "example.com",
 			Plugin:         "golang",
@@ -154,7 +154,7 @@ type unknownType int
 func (v unknownType) Type() string { return "unknown" }
 
 func TestUnknownType(t *testing.T) {
-	vl := api.ValueList{
+	vl := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:           "example.com",
 			Plugin:         "golang",

--- a/network/buffer_test.go
+++ b/network/buffer_test.go
@@ -2,6 +2,7 @@ package network // import "collectd.org/network"
 
 import (
 	"bytes"
+	"context"
 	"math"
 	"reflect"
 	"testing"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestWriteValueList(t *testing.T) {
+	ctx := context.Background()
 	b := NewBuffer(0)
 
 	vl := &api.ValueList{
@@ -24,7 +26,7 @@ func TestWriteValueList(t *testing.T) {
 		Values:   []api.Value{api.Derive(1)},
 	}
 
-	if err := b.Write(vl); err != nil {
+	if err := b.Write(ctx, vl); err != nil {
 		t.Errorf("Write got %v, want nil", err)
 		return
 	}
@@ -42,7 +44,7 @@ func TestWriteValueList(t *testing.T) {
 		Values:   []api.Value{api.Derive(2)},
 	}
 
-	if err := b.Write(vl); err != nil {
+	if err := b.Write(ctx, vl); err != nil {
 		t.Errorf("Write got %v, want nil", err)
 		return
 	}
@@ -154,6 +156,7 @@ type unknownType int
 func (v unknownType) Type() string { return "unknown" }
 
 func TestUnknownType(t *testing.T) {
+	ctx := context.Background()
 	vl := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:           "example.com",
@@ -167,7 +170,7 @@ func TestUnknownType(t *testing.T) {
 	}
 
 	s1 := NewBuffer(0)
-	if err := s1.Write(vl); err != ErrUnknownType {
+	if err := s1.Write(ctx, vl); err != ErrUnknownType {
 		t.Errorf("Buffer.Write(%v) = %v, want %v", vl, err, ErrUnknownType)
 	}
 

--- a/network/client.go
+++ b/network/client.go
@@ -49,7 +49,7 @@ func Dial(address string, opts ClientOptions) (*Client, error) {
 
 // Write adds a ValueList to the internal buffer. Data is only written to
 // the network when the buffer is full.
-func (c *Client) Write(vl api.ValueList) error {
+func (c *Client) Write(vl *api.ValueList) error {
 	if err := c.buffer.Write(vl); err != ErrNotEnoughSpace {
 		return err
 	}

--- a/network/client.go
+++ b/network/client.go
@@ -1,6 +1,7 @@
 package network // import "collectd.org/network"
 
 import (
+	"context"
 	"net"
 
 	"collectd.org/api"
@@ -49,8 +50,8 @@ func Dial(address string, opts ClientOptions) (*Client, error) {
 
 // Write adds a ValueList to the internal buffer. Data is only written to
 // the network when the buffer is full.
-func (c *Client) Write(vl *api.ValueList) error {
-	if err := c.buffer.Write(vl); err != ErrNotEnoughSpace {
+func (c *Client) Write(ctx context.Context, vl *api.ValueList) error {
+	if err := c.buffer.Write(ctx, vl); err != ErrNotEnoughSpace {
 		return err
 	}
 
@@ -58,7 +59,7 @@ func (c *Client) Write(vl *api.ValueList) error {
 		return err
 	}
 
-	return c.buffer.Write(vl)
+	return c.buffer.Write(ctx, vl)
 }
 
 // Flush writes the contents of the underlying buffer to the network

--- a/network/client_test.go
+++ b/network/client_test.go
@@ -1,6 +1,7 @@
 package network // import "collectd.org/network"
 
 import (
+	"context"
 	"log"
 	"net"
 	"time"
@@ -9,6 +10,7 @@ import (
 )
 
 func ExampleClient() {
+	ctx := context.Background()
 	conn, err := Dial(net.JoinHostPort("example.com", DefaultService), ClientOptions{})
 	if err != nil {
 		log.Fatal(err)
@@ -26,7 +28,7 @@ func ExampleClient() {
 		Values:   []api.Value{api.Gauge(42.0)},
 	}
 
-	if err := conn.Write(vl); err != nil {
+	if err := conn.Write(ctx, vl); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/network/client_test.go
+++ b/network/client_test.go
@@ -15,7 +15,7 @@ func ExampleClient() {
 	}
 	defer conn.Close()
 
-	vl := api.ValueList{
+	vl := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:   "example.com",
 			Plugin: "golang",

--- a/network/parse.go
+++ b/network/parse.go
@@ -32,7 +32,7 @@ type ParseOpts struct {
 // Parse parses the binary network format and returns a slice of ValueLists. If
 // a parse error is encountered, all ValueLists parsed to this point are
 // returned as well as the error. Unknown "parts" are silently ignored.
-func Parse(b []byte, opts ParseOpts) ([]api.ValueList, error) {
+func Parse(b []byte, opts ParseOpts) ([]*api.ValueList, error) {
 	return parse(b, None, opts)
 }
 
@@ -44,8 +44,8 @@ func readUint16(buf *bytes.Buffer) (uint16, error) {
 	return binary.BigEndian.Uint16(read), nil
 }
 
-func parse(b []byte, sl SecurityLevel, opts ParseOpts) ([]api.ValueList, error) {
-	var valueLists []api.ValueList
+func parse(b []byte, sl SecurityLevel, opts ParseOpts) ([]*api.ValueList, error) {
+	var valueLists []*api.ValueList
 
 	var state api.ValueList
 	buf := bytes.NewBuffer(b)
@@ -118,7 +118,7 @@ func parse(b []byte, sl SecurityLevel, opts ParseOpts) ([]api.ValueList, error) 
 			}
 
 			if opts.SecurityLevel <= sl {
-				valueLists = append(valueLists, vl)
+				valueLists = append(valueLists, &vl)
 			}
 
 		case typeSignSHA256:
@@ -235,7 +235,7 @@ func parseValues(b []byte) ([]api.Value, error) {
 	return values, nil
 }
 
-func parseSignSHA256(pkg, payload []byte, opts ParseOpts) ([]api.ValueList, error) {
+func parseSignSHA256(pkg, payload []byte, opts ParseOpts) ([]*api.ValueList, error) {
 	ok, err := verifySHA256(pkg, payload, opts.PasswordLookup)
 	if err != nil {
 		return nil, err
@@ -246,7 +246,7 @@ func parseSignSHA256(pkg, payload []byte, opts ParseOpts) ([]api.ValueList, erro
 	return parse(payload, Sign, opts)
 }
 
-func parseEncryptAES256(payload []byte, opts ParseOpts) ([]api.ValueList, error) {
+func parseEncryptAES256(payload []byte, opts ParseOpts) ([]*api.ValueList, error) {
 	plaintext, err := decryptAES256(payload, opts.PasswordLookup)
 	if err != nil {
 		return nil, errors.New("AES256 decryption failure")

--- a/network/parse_test.go
+++ b/network/parse_test.go
@@ -190,7 +190,7 @@ if_octets	rx:DERIVE:0:U, tx:DERIVE:0:U
 
 	for _, c := range cases {
 		netBuf := NewBuffer(0)
-		inVL := api.ValueList{
+		inVL := &api.ValueList{
 			Identifier: api.Identifier{
 				Host:   "example.com",
 				Plugin: "golang",
@@ -212,7 +212,7 @@ if_octets	rx:DERIVE:0:U, tx:DERIVE:0:U
 
 		vls, err := Parse(wireBuf, ParseOpts{TypesDB: typesDB})
 		if err != nil {
-			t.Errorf("Parse(%#v) = (%v, %v), want (%v, %v)", c, vls, err, "[]api.ValueList", nil)
+			t.Errorf("Parse(%#v) = (%v, %v), want (%v, %v)", c, vls, err, "[]*api.ValueList", nil)
 			continue
 		}
 		if c.WantErr {

--- a/network/parse_test.go
+++ b/network/parse_test.go
@@ -2,6 +2,7 @@ package network // import "collectd.org/network"
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -93,6 +94,8 @@ func TestRoundtrip(t *testing.T) {
 }
 
 func testRoundTrip(t *testing.T, file string) {
+	ctx := context.Background()
+
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		panic(err)
@@ -106,7 +109,7 @@ func testRoundTrip(t *testing.T, file string) {
 	}
 
 	b := NewBuffer(0)
-	if err := b.Write(vl[0]); err != nil {
+	if err := b.Write(ctx, vl[0]); err != nil {
 		panic(err)
 	}
 
@@ -124,6 +127,8 @@ func TestOneByte(t *testing.T) {
 }
 
 func TestParseOpts_TypesDB(t *testing.T) {
+	ctx := context.Background()
+
 	cases := []struct {
 		Type        string
 		Values      []api.Value
@@ -199,7 +204,7 @@ if_octets	rx:DERIVE:0:U, tx:DERIVE:0:U
 			Values: c.Values,
 		}
 
-		if err := netBuf.Write(inVL); err != nil {
+		if err := netBuf.Write(ctx, inVL); err != nil {
 			t.Errorf("Write(%#v): %v", inVL, err)
 			continue
 		}

--- a/network/server.go
+++ b/network/server.go
@@ -90,7 +90,7 @@ func (srv *Server) ListenAndWrite() error {
 	}
 }
 
-func dispatch(valueLists []api.ValueList, d api.Writer) {
+func dispatch(valueLists []*api.ValueList, d api.Writer) {
 	for _, vl := range valueLists {
 		if err := d.Write(vl); err != nil {
 			log.Printf("error while dispatching: %v", err)

--- a/network/server_test.go
+++ b/network/server_test.go
@@ -1,6 +1,7 @@
 package network // import "collectd.org/network"
 
 import (
+	"context"
 	"log"
 	"net"
 	"os"
@@ -18,7 +19,7 @@ func ExampleServer_ListenAndWrite() {
 	}
 
 	// blocks
-	log.Fatal(srv.ListenAndWrite())
+	log.Fatal(srv.ListenAndWrite(context.Background()))
 }
 
 // This example demonstrates how to forward received IPv6 multicast traffic to
@@ -36,5 +37,5 @@ func ExampleListenAndWrite() {
 	defer client.Close()
 
 	// blocks
-	log.Fatal(ListenAndWrite(":"+DefaultService, client))
+	log.Fatal(ListenAndWrite(context.Background(), ":"+DefaultService, client))
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -34,7 +34,7 @@ example:
 		  Values:   []api.Value{api.Gauge(42)},
 		  DSNames:  []string{"value"},
 	  }
-	  if err := plugin.Write(vl); err != nil {
+	  if err := plugin.Write(context.Background(), vl); err != nil {
 		  return err
 	  }
 
@@ -97,11 +97,16 @@ package plugin // import "collectd.org/plugin"
 import "C"
 
 import (
+	"context"
 	"fmt"
 	"unsafe"
 
 	"collectd.org/api"
 	"collectd.org/cdtime"
+)
+
+var (
+	ctx = context.Background()
 )
 
 // Reader defines the interface for read callbacks, i.e. Go functions that are
@@ -165,7 +170,7 @@ func NewWriter() api.Writer {
 }
 
 // Write implements the api.Writer interface for the collectd daemon.
-func (writer) Write(vl *api.ValueList) error {
+func (writer) Write(_ context.Context, vl *api.ValueList) error {
 	return Write(vl)
 }
 
@@ -303,7 +308,7 @@ func wrap_write_callback(ds *C.data_set_t, cvl *C.value_list_t, ud *C.user_data_
 		vl.DSNames = append(vl.DSNames, C.GoString(&dsrc.name[0]))
 	}
 
-	if err := w.Write(vl); err != nil {
+	if err := w.Write(ctx, vl); err != nil {
 		Errorf("%s plugin: Write() failed: %v", name, err)
 		return -1
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,7 +23,7 @@ example:
   type ExamplePlugin struct{}
 
   func (*ExamplePlugin) Read() error {
-	  vl := api.ValueList{
+	  vl := &api.ValueList{
 		  Identifier: api.Identifier{
 			  Host:   "example.com",
 			  Plugin: "goplug",
@@ -122,7 +122,7 @@ func strcpy(dst []C.char, src string) {
 	copy(dst, cStr)
 }
 
-func newValueListT(vl api.ValueList) (*C.value_list_t, error) {
+func newValueListT(vl *api.ValueList) (*C.value_list_t, error) {
 	ret := &C.value_list_t{}
 
 	strcpy(ret.host[:], vl.Host)
@@ -165,13 +165,13 @@ func NewWriter() api.Writer {
 }
 
 // Write implements the api.Writer interface for the collectd daemon.
-func (writer) Write(vl api.ValueList) error {
+func (writer) Write(vl *api.ValueList) error {
 	return Write(vl)
 }
 
 // Write converts a ValueList and calls the plugin_dispatch_values() function
 // of the collectd daemon.
-func Write(vl api.ValueList) error {
+func Write(vl *api.ValueList) error {
 	vlt, err := newValueListT(vl)
 	if err != nil {
 		return err
@@ -270,7 +270,7 @@ func wrap_write_callback(ds *C.data_set_t, cvl *C.value_list_t, ud *C.user_data_
 		return -1
 	}
 
-	vl := api.ValueList{
+	vl := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:           C.GoString(&cvl.host[0]),
 			Plugin:         C.GoString(&cvl.plugin[0]),


### PR DESCRIPTION
This changes the API in two ways:

*   All functions return or accept a *pointer* to a `ValueList` now. Previously `ValueList`s were passed by value, which is a bit too expensive given the struct's size.
*   The `api.Writer` interface now passes a `context.Context` to the write function. The `context` package is new in Go 1.7, so that version is required with this change.