### PR TITLE
Package plugin: Add support for Shutdown callback

### DIFF
--- a/plugin/c.go
+++ b/plugin/c.go
@@ -87,4 +87,15 @@ package plugin // import "collectd.org/plugin"
 //   }
 //   return (*register_write_ptr) (name, callback, user_data);
 // }
+//
+// int (*register_shutdown_ptr) (char *, plugin_shutdown_cb);
+// int register_shutdown_wrapper (char *name, plugin_shutdown_cb callback) {
+//   if (register_shutdown_ptr == NULL) {
+//     void *hnd = dlopen(NULL, RTLD_LAZY);
+//     register_shutdown_ptr = dlsym(hnd, "plugin_register_shutdown");
+//     dlclose(hnd);
+//   }
+//   return (*register_shutdown_ptr) (name, callback);
+//
+// }
 import "C"


### PR DESCRIPTION
Hi,

This patch introduces support for the Shutdown callback in Go plugins, modeled after the existing read and write callbacks. If it's of use I'd be happy to have a crack at implementing the remaining callbacks. Any and all feedback would be appreciated.

Kind regards,
Ashley
