### PR TITLE
minor correction to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Utilities for using [collectd](https://collectd.org/) together with [Go](http://
             Interval: exec.Interval(),
             Values:   []api.Value{api.Gauge(42)},
         }
-        exec.Putval.Write(context.Background(), vl)
+        exec.Putval.Write(context.Background(), &vl)
     }
 
 # Description


### PR DESCRIPTION
- would give "cannot use vl (type api.ValueList) as type *api.ValueList in argument to exec.Putval.Write" before