### PR TITLE
Package plugin: implement complex config callback

### DIFF
--- a/plugin/c.go
+++ b/plugin/c.go
@@ -142,4 +142,14 @@ package plugin // import "collectd.org/plugin"
 //   }
 //   return (*register_complex_config_ptr) (name, callback);
 // }
+//
+// int (*register_init_ptr) (char *, plugin_init_cb);
+// int register_init_wrapper (char *name, plugin_init_cb callback) {
+//   if (register_init_ptr == NULL) {
+//     void *hnd = dlopen(NULL, RTLD_LAZY);
+//     register_init_ptr = dlsym(hnd, "plugin_register_init");
+//     dlclose(hnd);
+//   }
+//   return (*register_init_ptr) (name, callback);
+// }
 import "C"

--- a/plugin/c.go
+++ b/plugin/c.go
@@ -8,6 +8,8 @@ package plugin // import "collectd.org/plugin"
 // #include <stdlib.h>
 // #include <dlfcn.h>
 //
+// typedef int (*plugin_complex_config_cb)(oconfig_item_t*);
+//
 // int (*register_read_ptr) (char const *group, char const *name,
 //     plugin_read_cb callback,
 //     cdtime_t interval,
@@ -97,5 +99,47 @@ package plugin // import "collectd.org/plugin"
 //   }
 //   return (*register_shutdown_ptr) (name, callback);
 //
+// }
+//
+// double go_get_number_value (oconfig_item_t *ci, int i) {
+//	if (i >= ci->values_num) {
+//		errno = EINVAL;
+//		return 0;
+//	}
+//	return ci->values[i].value.number;
+// }
+//
+// int go_get_boolean_value (oconfig_item_t *ci, int i) {
+//	if (i >= ci->values_num) {
+//		errno = EINVAL;
+//		return 0;
+//	}
+//	return ci->values[i].value.boolean;
+// }
+//
+// char *go_get_string_value (oconfig_item_t *ci, int i) {
+//	if (i >= ci->values_num) {
+//		errno = EINVAL;
+//		return "";
+//	}
+//	return ci->values[i].value.string;
+// }
+//
+// int go_get_value_type (oconfig_item_t *ci, int i) {
+//	if (i >= ci->values_num) {
+//		errno = EINVAL;
+//		return -1;
+//	}
+//	return ci->values[i].type;
+// }
+//
+// int (*register_complex_config_ptr) (char *, plugin_complex_config_cb);
+// int register_complex_config_wrapper (char *name, plugin_complex_config_cb callback) {
+//   if (register_complex_config_ptr == NULL) {
+//     void *hnd = dlopen(NULL, RTLD_LAZY);
+//     register_complex_config_ptr = dlsym(hnd, "plugin_register_complex_config");
+//     dlclose(hnd);
+//   }
+//   return (*register_complex_config_ptr) (name, callback);
 // }
 import "C"

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -90,6 +90,8 @@ package plugin // import "collectd.org/plugin"
 // derive_t  value_list_get_derive  (value_list_t *, size_t);
 // gauge_t   value_list_get_gauge   (value_list_t *, size_t);
 //
+// typedef int (*plugin_complex_config_cb)(oconfig_item_t);
+//
 // int wrap_read_callback(user_data_t *);
 //
 // int register_write_wrapper (char const *, plugin_write_cb, user_data_t *);
@@ -97,15 +99,22 @@ package plugin // import "collectd.org/plugin"
 //
 // int register_shutdown_wrapper (char *, plugin_shutdown_cb);
 // int wrap_shutdown_callback(void);
+//
+// int register_complex_config_wrapper (char *, plugin_complex_config_cb);
+// int process_complex_config(oconfig_item_t*);
+// char *go_get_string_value(oconfig_item_t*, int);
+// double go_get_number_value(oconfig_item_t*, int);
+// int go_get_boolean_value(oconfig_item_t*, int);
+// int go_get_value_type(oconfig_item_t*, int);
 import "C"
 
 import (
-	"context"
-	"fmt"
-	"unsafe"
-
 	"collectd.org/api"
 	"collectd.org/cdtime"
+	"context"
+	"fmt"
+	"reflect"
+	"unsafe"
 )
 
 var (
@@ -332,6 +341,7 @@ var shutdownFuncs = make(map[string]Shutter)
 
 //export wrap_shutdown_callback
 func wrap_shutdown_callback() C.int {
+	fmt.Println("wrap_shutdown_callback called")
 	if len(shutdownFuncs) <= 0 {
 		return 0
 	}
@@ -361,6 +371,231 @@ func RegisterShutdown(name string, s Shutter) error {
 	}
 	shutdownFuncs[name] = s
 	return nil
+}
+
+// Configuration defines the interface for complex_configure callbacks, i.e. Go
+// structs that can hold and validate a configuration
+type Configuration interface {
+	Validate() error
+}
+
+var config_target *Configuration
+var config_targets map[string]*Configuration
+
+var configured map[string]chan struct{}
+
+// getOconfigChildren takes a C.oconfig_item_t and returns an array of Go
+// pointers to its child items. Getting the child pointers requires a little
+// more arithmetic than in C as we can't just increment a pointer to get the
+// next array item
+func getOconfigChildren(oconfig *C.oconfig_item_t) (output []*C.oconfig_item_t) {
+	start := unsafe.Pointer(oconfig.children)
+	size := unsafe.Sizeof(*oconfig.children)
+	for i := 0; i < int(oconfig.children_num); i++ {
+		child := (*C.oconfig_item_t)(unsafe.Pointer(uintptr(start) + size*uintptr(i)))
+		output = append(output, child)
+	}
+	return
+}
+
+// checkMatchable returns an error if the provided source cannot be copied to
+// the target, or nil if it's OK
+func checkMatchable(oconfig *C.oconfig_item_t, target reflect.Value) error {
+	if oconfig.children_num > 0 { // if it has children we need a corresponding struct
+		if target.Kind() != reflect.Struct {
+			return fmt.Errorf("did not have corresponding struct")
+		}
+	}
+	if oconfig.values_num > 1 { // if it has multiple values we need a slice
+		if target.Kind() != reflect.Slice {
+			return fmt.Errorf("did not have corresponding slice")
+		}
+	}
+	if oconfig.values_num == 1 { // if it has a single value we need either a string, int or bool
+		valType, err := C.go_get_value_type(oconfig, C.int(0))
+		if err != nil {
+			return fmt.Errorf("unable to determine type of value")
+		}
+		switch valType {
+		case C.int(0): //string
+			if target.Kind() != reflect.String {
+				return fmt.Errorf("found string, plugin expects %v", target.Kind().String())
+			}
+		case C.int(1): // number/double/float64
+			if target.Kind() != reflect.Float64 {
+				return fmt.Errorf("found number, plugin expects %v", target.Kind().String())
+			}
+		case C.int(2): // boolean
+			if target.Kind() != reflect.Bool {
+				return fmt.Errorf("found boolean, plugin expects %v", target.Kind().String())
+			}
+		default:
+			return fmt.Errorf("unsupported Collectd config item type")
+		}
+	}
+	return nil
+}
+
+// checkUsable iterates over a provided reflect.Value and attempts to make sure
+// it A) contains only string, bool, or float64 fields, or slices or structs of
+// these, and B) contains only settable, exported fields
+// Unfortunately as we start with a reflect.Value and no reflect.Type we can't
+// actually report the name of the failing field. Fortunately this should be a
+// plugin error only (not possible for a user to trigger) and resolved during
+// notmal testing.
+func checkUsable(target reflect.Value) error {
+	switch target.Kind().String() {
+	case "struct":
+		for i := 0; i < target.NumField(); i++ {
+			err := checkUsable(target.Field(i))
+			if err != nil {
+				return fmt.Errorf("in struct: %v", err)
+			}
+		}
+	case "slice":
+		if target.CanSet() != true {
+			return fmt.Errorf("unsettable value (unexported field?)")
+		}
+		// Get an Interface of the slice, extract a field and get the field's type
+		switch reflect.TypeOf(target.Interface()).Elem().Kind() {
+		case reflect.String:
+		case reflect.Float64:
+		case reflect.Bool:
+		default:
+			return fmt.Errorf("unsupported variable type (slices must be of string, float64, or bool)")
+		}
+	case "string":
+		if target.CanSet() != true {
+			return fmt.Errorf("unsettable value (unexported field?)")
+		}
+		return nil
+	case "float64":
+		if target.CanSet() != true {
+			return fmt.Errorf("unsettable value (unexported field?)")
+		}
+		return nil
+	case "bool":
+		if target.CanSet() != true {
+			return fmt.Errorf("unsettable value (unexported field?)")
+		}
+		return nil
+	default:
+		fmt.Println(target.Kind().String())
+		return fmt.Errorf("unsupported variable type (must be string, float64, bool, or slice of these, or struct)")
+	}
+	return nil // here to keep the compiler happy
+}
+
+// assignValue copies a oconfig_value to a target Value using the appropriate function
+func assignValue(oconfig_item *C.oconfig_item_t, target reflect.Value, index int) error {
+	valType, err := C.go_get_value_type(oconfig_item, C.int(index))
+	if err != nil {
+		return fmt.Errorf("unable to determine type of value")
+	}
+	switch valType {
+	case C.int(0): //string
+		target.SetString(C.GoString(C.go_get_string_value(oconfig_item, C.int(index))))
+	case C.int(1): // number/double/float64
+		target.SetFloat(float64(C.go_get_number_value(oconfig_item, C.int(index))))
+	case C.int(2): // boolean
+		target.SetBool(C.go_get_number_value(oconfig_item, C.int(index)) == 1)
+	default: // Unknown type
+		return fmt.Errorf("unsupported config item type")
+	}
+	return nil
+}
+
+// assignSlice generates a slice of the target type, loads in each value and assigns it to the target
+func assignSlice(oconfig_item *C.oconfig_item_t, target reflect.Value) error {
+	s := reflect.MakeSlice(target.Type(), int(oconfig_item.values_num), int(oconfig_item.values_num))
+	for i := 0; i < int(oconfig_item.values_num); i++ {
+		assignValue(oconfig_item, s.Index(i), i)
+	}
+	target.Set(s)
+	return nil
+}
+
+// assignConfig takes an oconfig_item_t struct and attempts to assign data to corresponding
+// fields in the provided config_target. A lack of corresponding field is not an error, a
+// corresponding field of the wrong type is.
+func assignConfig(oconfig *C.oconfig_item_t, target reflect.Value, isRoot bool) error {
+	// root oconfig_item's value is the name of the plugin and unused here
+	if isRoot != true {
+		if err := checkMatchable(oconfig, target); err != nil {
+			return fmt.Errorf("unmatchable value (%v)", err)
+		}
+	}
+	if int(oconfig.values_num) > 1 { // multiple values
+		assignSlice(oconfig, target)
+	} else if (oconfig.values_num == 1) && (isRoot == false) { // single value
+		assignValue(oconfig, target, 0)
+	} else if oconfig.children_num > 0 { // a container of oconfig children
+		for _, child := range getOconfigChildren(oconfig) {
+			childkey := C.GoString(child.key)
+			if target.FieldByName(childkey).IsValid() != true { // if there's no corresponding target field, skip it
+				fmt.Printf("Ignoring unexpected key in config: %v\n", childkey)
+				continue
+			}
+			if err := assignConfig(child, target.FieldByName(childkey), false); err != nil {
+				return fmt.Errorf("in %v: %v\n", childkey, err)
+			}
+		}
+	}
+	return nil
+}
+
+// RequestConfiguration registers a Configuration struct with the daemon and
+// requests a callback to fill it in. It returns a channel which will be
+// closed when a configuration has been loaded successfully
+func RequestConfiguration(name string, c Configuration) (chan struct{}, error) {
+	if err := checkUsable(reflect.ValueOf(c).Elem()); err != nil {
+		fmt.Printf("while loading plugin received error: %v\n", err)
+		return nil, fmt.Errorf("plugin contains unusable configuration struct")
+	}
+	if len(config_targets) == 0 {
+		config_targets = make(map[string]*Configuration)
+		configured = make(map[string]chan struct{})
+	}
+	config_targets[name] = &c
+	configured[name] = make(chan struct{})
+	cName := C.CString(name)
+	cCallback := C.plugin_complex_config_cb(C.process_complex_config)
+	status, err := C.register_complex_config_wrapper(cName, cCallback)
+	if err != nil {
+		Errorf("register_complex_config_wrapper failed with status %v", status)
+		return nil, err
+	}
+	return configured[name], nil
+}
+
+// process_complex_config receives the plugin config from Collectd and attempts to
+// initialise the target config. If the configuration is parsed without fatal errors
+// it calls the attached Validate() function, which allows the plugin developer to
+// confirm that they've received sufficient valid configuration. If that succeeds
+// we finally close the Configured channel to indicate that the configuration is now
+// assigned and validated.
+//export process_complex_config
+func process_complex_config(oconfig *C.oconfig_item_t) C.int {
+	oname := C.GoString(C.go_get_string_value(oconfig, C.int(0)))
+	var ok bool
+	if config_target, ok = config_targets[oname]; !ok {
+		fmt.Printf("Error: Received configuration for unknown plugin name %v\n", oname)
+		return C.int(1)
+	}
+	target := reflect.ValueOf(*config_target).Elem()
+	err := assignConfig(oconfig, target, true)
+	if err != nil {
+		fmt.Printf("Error: Invalid configuration %v\n", err)
+		return C.int(1)
+	}
+	valArgs := make([]reflect.Value, 0)
+	valResp := target.MethodByName("Validate").Call(valArgs)
+	if err := valResp[0].Interface(); err != nil {
+		fmt.Printf("Error: Plugin-specific validation returned error: %v\n", err)
+		return C.int(1)
+	}
+	close(configured[oname])
+	return C.int(0)
 }
 
 //export module_register

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -379,8 +379,8 @@ type Configuration interface {
 	Validate() error
 }
 
-var config_target *Configuration
-var config_targets map[string]*Configuration
+var config_target Configuration
+var config_targets map[string]Configuration
 
 var configured map[string]chan struct{}
 
@@ -418,11 +418,16 @@ func checkMatchable(oconfig *C.oconfig_item_t, target reflect.Value) error {
 		}
 		switch valType {
 		case C.int(0): //string
-			if target.Kind() != reflect.String {
+			// for comparison purposes treat slices the same as their element type
+			k := target.Kind()
+			if k == reflect.Slice {
+				k = target.Type().Elem().Kind()
+			}
+			if k != reflect.String {
 				return fmt.Errorf("found string, plugin expects %v", target.Kind().String())
 			}
 		case C.int(1): // number/double/float64
-			if target.Kind() != reflect.Float64 {
+			if !reflect.TypeOf(float64(0)).AssignableTo(target.Type()) {
 				return fmt.Errorf("found number, plugin expects %v", target.Kind().String())
 			}
 		case C.int(2): // boolean
@@ -437,53 +442,46 @@ func checkMatchable(oconfig *C.oconfig_item_t, target reflect.Value) error {
 }
 
 // checkUsable iterates over a provided reflect.Value and attempts to make sure
-// it A) contains only string, bool, or float64 fields, or slices or structs of
-// these, and B) contains only settable, exported fields
+// it A) contains only string, bool, int, int64, or float64 fields, or slices
+// or structs of these, and B) contains only settable, exported fields
 // Unfortunately as we start with a reflect.Value and no reflect.Type we can't
 // actually report the name of the failing field. Fortunately this should be a
 // plugin error only (not possible for a user to trigger) and resolved during
-// notmal testing.
+// normal testing.
 func checkUsable(target reflect.Value) error {
-	switch target.Kind().String() {
-	case "struct":
+	if target.Kind() == reflect.Struct {
 		for i := 0; i < target.NumField(); i++ {
 			err := checkUsable(target.Field(i))
 			if err != nil {
 				return fmt.Errorf("in struct: %v", err)
 			}
 		}
-	case "slice":
-		if target.CanSet() != true {
-			return fmt.Errorf("unsettable value (unexported field?)")
-		}
-		// Get an Interface of the slice, extract a field and get the field's type
-		switch reflect.TypeOf(target.Interface()).Elem().Kind() {
+		return nil
+	}
+	switch target.Kind() {
+	case reflect.Slice:
+		// Get the slice type, then the type of its elements, then reflect.Kind for matching
+		switch target.Type().Elem().Kind() {
 		case reflect.String:
+		case reflect.Int64:
+		case reflect.Int:
 		case reflect.Float64:
 		case reflect.Bool:
 		default:
-			return fmt.Errorf("unsupported variable type (slices must be of string, float64, or bool)")
+			return fmt.Errorf("unsupported variable type (slices must be of string, int, int64, float64, or bool)")
 		}
-	case "string":
-		if target.CanSet() != true {
-			return fmt.Errorf("unsettable value (unexported field?)")
-		}
-		return nil
-	case "float64":
-		if target.CanSet() != true {
-			return fmt.Errorf("unsettable value (unexported field?)")
-		}
-		return nil
-	case "bool":
-		if target.CanSet() != true {
-			return fmt.Errorf("unsettable value (unexported field?)")
-		}
-		return nil
+	case reflect.String:
+	case reflect.Int64:
+	case reflect.Int:
+	case reflect.Float64:
+	case reflect.Bool:
 	default:
-		fmt.Println(target.Kind().String())
-		return fmt.Errorf("unsupported variable type (must be string, float64, bool, or slice of these, or struct)")
+		return fmt.Errorf("unsupported variable type (must be string, int, int64, float64, bool, or slice of these, or struct)")
 	}
-	return nil // here to keep the compiler happy
+	if target.CanSet() != true {
+		return fmt.Errorf("unsettable value (unexported field?)")
+	}
+	return nil // No errors found
 }
 
 // assignValue copies a oconfig_value to a target Value using the appropriate function
@@ -496,7 +494,14 @@ func assignValue(oconfig_item *C.oconfig_item_t, target reflect.Value, index int
 	case C.int(0): //string
 		target.SetString(C.GoString(C.go_get_string_value(oconfig_item, C.int(index))))
 	case C.int(1): // number/double/float64
-		target.SetFloat(float64(C.go_get_number_value(oconfig_item, C.int(index))))
+		switch target.Kind() {
+		case reflect.Float64:
+			target.SetFloat(float64(C.go_get_number_value(oconfig_item, C.int(index))))
+		case reflect.Int:
+			target.SetInt(int64(C.go_get_number_value(oconfig_item, C.int(index))))
+		case reflect.Int64:
+			target.SetInt(int64(C.go_get_number_value(oconfig_item, C.int(index))))
+		}
 	case C.int(2): // boolean
 		target.SetBool(C.go_get_number_value(oconfig_item, C.int(index)) == 1)
 	default: // Unknown type
@@ -519,17 +524,21 @@ func assignSlice(oconfig_item *C.oconfig_item_t, target reflect.Value) error {
 // fields in the provided config_target. A lack of corresponding field is not an error, a
 // corresponding field of the wrong type is.
 func assignConfig(oconfig *C.oconfig_item_t, target reflect.Value, isRoot bool) error {
-	// root oconfig_item's value is the name of the plugin and unused here
+
+	// TODO: Properly implement this
+
+	// the root oconfig_item is processed slightly differently
 	if isRoot != true {
 		if err := checkMatchable(oconfig, target); err != nil {
 			return fmt.Errorf("unmatchable value (%v)", err)
 		}
+		if int(oconfig.values_num) > 1 { // multiple values
+			assignSlice(oconfig, target)
+		} else if oconfig.values_num == 1 { // single value
+			assignValue(oconfig, target, 0)
+		}
 	}
-	if int(oconfig.values_num) > 1 { // multiple values
-		assignSlice(oconfig, target)
-	} else if (oconfig.values_num == 1) && (isRoot == false) { // single value
-		assignValue(oconfig, target, 0)
-	} else if oconfig.children_num > 0 { // a container of oconfig children
+	if oconfig.children_num > 0 { // a container of oconfig children
 		for _, child := range getOconfigChildren(oconfig) {
 			childkey := C.GoString(child.key)
 			if target.FieldByName(childkey).IsValid() != true { // if there's no corresponding target field, skip it
@@ -553,12 +562,13 @@ func RequestConfiguration(name string, c Configuration) (chan struct{}, error) {
 		return nil, fmt.Errorf("plugin contains unusable configuration struct")
 	}
 	if len(config_targets) == 0 {
-		config_targets = make(map[string]*Configuration)
+		config_targets = make(map[string]Configuration)
 		configured = make(map[string]chan struct{})
 	}
-	config_targets[name] = &c
+	config_targets[name] = c
 	configured[name] = make(chan struct{})
 	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
 	cCallback := C.plugin_complex_config_cb(C.process_complex_config)
 	status, err := C.register_complex_config_wrapper(cName, cCallback)
 	if err != nil {
@@ -582,15 +592,13 @@ func process_complex_config(oconfig *C.oconfig_item_t) C.int {
 		fmt.Printf("Error: Received configuration for unknown plugin name %v\n", oname)
 		return C.int(1)
 	}
-	target := reflect.ValueOf(*config_target).Elem()
+	target := reflect.ValueOf(config_target).Elem()
 	err := assignConfig(oconfig, target, true)
 	if err != nil {
 		fmt.Printf("Error: Invalid configuration %v\n", err)
 		return C.int(1)
 	}
-	valArgs := make([]reflect.Value, 0)
-	valResp := target.MethodByName("Validate").Call(valArgs)
-	if err := valResp[0].Interface(); err != nil {
+	if err := config_target.Validate(); err != nil {
 		fmt.Printf("Error: Plugin-specific validation returned error: %v\n", err)
 		return C.int(1)
 	}


### PR DESCRIPTION
Hi octo,

This pull request covers the implementation of the complex_config callback. It allows plugin authors to define a struct that both specifies and holds a desired configuration structure from the main config file. I've tried to be helpful to both the plugin author and end-user by validating the configuration and struct as far as possible.

- The `RequestConfiguration(name string, c Configuration) (chan struct{}, error)` function registers the configuration callback and kicks off the process of parsing the configuration. On success it returns a `chan struct{}` which is only closed when the configuration is fully parsed and validated. This acts as the semaphore preventing concurrent memory access by allowing the plugin author to block until the parsing functions are finished.

- The Configuration interface requires a method `Validate() error` to be implemented, which allows the plugin author to specify any configuration validation they feel necessary. The function is called once the struct is filled and if it returns != nil collectd exits with the error message provided.

Documentation including examples will follow shortly but your review of this code would be greatly appreciated.

-- alowde