### PR TITLE
Package network: Add the DefaultPort constant.

### DIFF
--- a/network/main.go
+++ b/network/main.go
@@ -8,6 +8,7 @@ const (
 	DefaultIPv4Address = "239.192.74.66"
 	DefaultIPv6Address = "ff18::efc0:4a42"
 	DefaultService     = "25826"
+	DefaultPort        = 25826
 )
 
 // Default size of "Buffer". This is based on the maximum bytes that fit into


### PR DESCRIPTION
This is an integer variant of DefaultService for use in places that expect
integers.