### PR TITLE
Package meta: meta data for api.ValueList

### DIFF
--- a/api/json.go
+++ b/api/json.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"collectd.org/cdtime"
+	"collectd.org/meta"
 )
 
 // jsonValueList represents the format used by collectd's JSON export.
@@ -19,6 +20,7 @@ type jsonValueList struct {
 	PluginInstance string        `json:"plugin_instance,omitempty"`
 	Type           string        `json:"type"`
 	TypeInstance   string        `json:"type_instance,omitempty"`
+	Meta           meta.Data     `json:"meta,omitempty"`
 }
 
 // MarshalJSON implements the "encoding/json".Marshaler interface for
@@ -35,6 +37,7 @@ func (vl *ValueList) MarshalJSON() ([]byte, error) {
 		PluginInstance: vl.PluginInstance,
 		Type:           vl.Type,
 		TypeInstance:   vl.TypeInstance,
+		Meta:           vl.Meta,
 	}
 
 	for i, v := range vl.Values {
@@ -114,6 +117,8 @@ func (vl *ValueList) UnmarshalJSON(data []byte) error {
 		vl.DSNames = make([]string, len(vl.Values))
 		copy(vl.DSNames, jvl.DSNames)
 	}
+
+	vl.Meta = jvl.Meta
 
 	return nil
 }

--- a/api/json_test.go
+++ b/api/json_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"collectd.org/meta"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestValueList(t *testing.T) {
@@ -31,8 +32,11 @@ func TestValueList(t *testing.T) {
 	want := `{"values":[42],"dstypes":["gauge"],"dsnames":["legacy"],"time":1426585562.999,"interval":10.000,"host":"example.com","plugin":"golang","type":"gauge","meta":{"foo":"bar"}}`
 
 	got, err := vlWant.MarshalJSON()
-	if err != nil || string(got) != want {
-		t.Errorf("got (%s, %v), want (%s, nil)", got, err, want)
+	if err != nil {
+		t.Fatalf("ValueList.MarshalJSON() = %v", err)
+	}
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("ValueList.MarshalJSON() differs (+got/-want):\n%s", diff)
 	}
 
 	var vlGot ValueList

--- a/api/json_test.go
+++ b/api/json_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"collectd.org/meta"
 )
 
 func TestValueList(t *testing.T) {
@@ -21,9 +23,12 @@ func TestValueList(t *testing.T) {
 		Interval: 10 * time.Second,
 		Values:   []Value{Gauge(42)},
 		DSNames:  []string{"legacy"},
+		Meta: meta.Data{
+			"foo": meta.String("bar"),
+		},
 	}
 
-	want := `{"values":[42],"dstypes":["gauge"],"dsnames":["legacy"],"time":1426585562.999,"interval":10.000,"host":"example.com","plugin":"golang","type":"gauge"}`
+	want := `{"values":[42],"dstypes":["gauge"],"dsnames":["legacy"],"time":1426585562.999,"interval":10.000,"host":"example.com","plugin":"golang","type":"gauge","meta":{"foo":"bar"}}`
 
 	got, err := vlWant.MarshalJSON()
 	if err != nil || string(got) != want {

--- a/api/main.go
+++ b/api/main.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"collectd.org/meta"
 	"go.uber.org/multierr"
 )
 
@@ -87,6 +88,7 @@ type ValueList struct {
 	Interval time.Duration
 	Values   []Value
 	DSNames  []string
+	Meta     meta.Data
 }
 
 // DSName returns the name of the data source at the given index. If vl.DSNames
@@ -118,6 +120,8 @@ func (vl *ValueList) Clone() *ValueList {
 
 	vlCopy.DSNames = make([]string, len(vl.DSNames))
 	copy(vlCopy.DSNames, vl.DSNames)
+
+	vlCopy.Meta = vl.Meta.Clone()
 
 	return &vlCopy
 }

--- a/format/putval_test.go
+++ b/format/putval_test.go
@@ -8,6 +8,8 @@ import (
 
 	"collectd.org/api"
 	"collectd.org/format"
+	"collectd.org/meta"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestPutval(t *testing.T) {
@@ -78,6 +80,16 @@ func TestPutval(t *testing.T) {
 			},
 			want: `PUTVAL "example.com/TestPutval/derive" interval=9.877 N:42` + "\n",
 		},
+		{
+			title: "meta_data",
+			modify: func(vl *api.ValueList) {
+				vl.Meta = meta.Data{
+					"key":     meta.String("value"),
+					"ignored": meta.Bool(true),
+				}
+			},
+			want: `PUTVAL "example.com/TestPutval/derive" interval=10.000 meta:key="value" N:42` + "\n",
+		},
 	}
 
 	for _, tc := range cases {
@@ -98,8 +110,8 @@ func TestPutval(t *testing.T) {
 				return
 			}
 
-			if got := b.String(); got != tc.want {
-				t.Errorf("Putval.Write(%#v): got %q, want %q", &vl, got, tc.want)
+			if diff := cmp.Diff(tc.want, b.String()); diff != "" {
+				t.Errorf("Putval.Write(%#v) differs (+got/-want):\n%s", &vl, diff)
 			}
 		})
 	}

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -21,26 +21,12 @@ const (
 	metaBoolType
 )
 
-// Entry is the interface implemented by all meta data entries. The types
-// implementing this interface are String, Int64, UInt64, Float64 and Bool. The
-// interface contains private functions to prevent other packages from
-// implementing it, so that the use really is limited to the previously listed
-// types.
-type Entry interface {
-	String() (string, bool)
-	Int64() (int64, bool)
-	UInt64() (uint64, bool)
-	Float64() (float64, bool)
-	Bool() (bool, bool)
-
-	getType() entryType
-}
-
 // Data is a map of meta data values. No setter and getter methods are
 // implemented for this, callers are expected to add and remove entries as they
 // would from a normal map.
 type Data map[string]Entry
 
+// Clone returns a copy of d.
 func (d Data) Clone() Data {
 	if d == nil {
 		return nil
@@ -53,196 +39,143 @@ func (d Data) Clone() Data {
 	return cpy
 }
 
-// UnmarshalJSON implements the "encoding/json".Unmarshaller interface.
-func (d *Data) UnmarshalJSON(raw []byte) error {
-	var m map[string]jsonEntry
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return err
-	}
+// Entry is an entry in the metadata set. The typed value may be bool, float64,
+// int64, uint64, or string.
+type Entry struct {
+	s string
+	i int64
+	u uint64
+	f float64
+	b bool
 
-	for k, v := range m {
-		if *d == nil {
-			*d = Data{}
+	typ entryType
+}
+
+// Bool returns a new bool Entry.
+func Bool(b bool) Entry { return Entry{b: b, typ: metaBoolType} }
+
+// Float64 returns a new float64 Entry.
+func Float64(f float64) Entry { return Entry{f: f, typ: metaFloat64Type} }
+
+// Int64 returns a new int64 Entry.
+func Int64(i int64) Entry { return Entry{i: i, typ: metaInt64Type} }
+
+// UInt64 returns a new uint64 Entry.
+func UInt64(u uint64) Entry { return Entry{u: u, typ: metaUInt64Type} }
+
+// String returns a new string Entry.
+func String(s string) Entry { return Entry{s: s, typ: metaStringType} }
+
+// Bool returns the bool value of e.
+func (e Entry) Bool() (value, ok bool) { return e.b, e.typ == metaBoolType }
+
+// Float64 returns the float64 value of e.
+func (e Entry) Float64() (float64, bool) { return e.f, e.typ == metaFloat64Type }
+
+// Int64 returns the int64 value of e.
+func (e Entry) Int64() (int64, bool) { return e.i, e.typ == metaInt64Type }
+
+// UInt64 returns the uint64 value of e.
+func (e Entry) UInt64() (uint64, bool) { return e.u, e.typ == metaUInt64Type }
+
+// String returns a string representation of e.
+func (e Entry) String() string {
+	switch e.typ {
+	case metaBoolType:
+		return fmt.Sprintf("%v", e.b)
+	case metaFloat64Type:
+		return fmt.Sprintf("%.15g", e.f)
+	case metaInt64Type:
+		return fmt.Sprintf("%v", e.i)
+	case metaUInt64Type:
+		return fmt.Sprintf("%v", e.u)
+	case metaStringType:
+		return e.s
+	default:
+		return fmt.Sprintf("%v", nil)
+	}
+}
+
+// IsString returns true if e is a string value.
+func (e Entry) IsString() bool {
+	return e.typ == metaStringType
+}
+
+// Interface returns e's value. It is intended to be used with type switches
+// and when printing an entry's type with the "%T" formatting.
+func (e Entry) Interface() interface{} {
+	switch e.typ {
+	case metaBoolType:
+		return e.b
+	case metaFloat64Type:
+		return e.f
+	case metaInt64Type:
+		return e.i
+	case metaUInt64Type:
+		return e.u
+	case metaStringType:
+		return e.s
+	default:
+		return nil
+	}
+}
+
+// MarshalJSON implements the "encoding/json".Marshaller interface.
+func (e Entry) MarshalJSON() ([]byte, error) {
+	switch e.typ {
+	case metaBoolType:
+		return json.Marshal(e.b)
+	case metaFloat64Type:
+		if math.IsNaN(e.f) {
+			return json.Marshal(nil)
 		}
-		(*d)[k] = v.Entry
+		return json.Marshal(e.f)
+	case metaInt64Type:
+		return json.Marshal(e.i)
+	case metaUInt64Type:
+		return json.Marshal(e.u)
+	case metaStringType:
+		return json.Marshal(e.s)
+	default:
+		return json.Marshal(nil)
 	}
-	return nil
 }
 
-// jsonEntry is a helper type implementing "encoding/json".Unmarshaller for Entry.
-type jsonEntry struct {
-	Entry
-}
-
-func (e *jsonEntry) UnmarshalJSON(raw []byte) error {
+// UnmarshalJSON implements the "encoding/json".Unmarshaller interface.
+func (e *Entry) UnmarshalJSON(raw []byte) error {
 	var b *bool
 	if json.Unmarshal(raw, &b) == nil && b != nil {
-		e.Entry = Bool(*b)
+		*e = Bool(*b)
 		return nil
 	}
 
 	var s *string
 	if json.Unmarshal(raw, &s) == nil && s != nil {
-		e.Entry = String(*s)
+		*e = String(*s)
 		return nil
 	}
 
 	var i *int64
 	if json.Unmarshal(raw, &i) == nil && i != nil {
-		e.Entry = Int64(*i)
+		*e = Int64(*i)
 		return nil
 	}
 
 	var u *uint64
 	if json.Unmarshal(raw, &u) == nil && u != nil {
-		e.Entry = UInt64(*u)
+		*e = UInt64(*u)
 		return nil
 	}
 
 	var f *float64
 	if json.Unmarshal(raw, &f) == nil {
-		if f == nil {
-			nan := math.NaN()
-			f = &nan
+		if f != nil {
+			*e = Float64(*f)
+		} else {
+			*e = Float64(math.NaN())
 		}
-		e.Entry = Float64(*f)
 		return nil
 	}
 
 	return fmt.Errorf("unable to parse %q as meta entry", raw)
-}
-
-// String is a string implementing the Entry interface.
-type String string
-
-func (s String) String() (string, bool) {
-	return string(s), true
-}
-
-func (String) Int64() (int64, bool) {
-	return 0, false
-}
-
-func (String) UInt64() (uint64, bool) {
-	return 0, false
-}
-
-func (String) Float64() (float64, bool) {
-	return 0, false
-}
-
-func (String) Bool() (bool, bool) {
-	return false, false
-}
-
-func (String) getType() entryType {
-	return metaStringType
-}
-
-// Int64 is a int64 implementing the Entry interface.
-type Int64 int64
-
-func (Int64) String() (string, bool) {
-	return "", false
-}
-
-func (s Int64) Int64() (int64, bool) {
-	return int64(s), true
-}
-
-func (Int64) UInt64() (uint64, bool) {
-	return 0, false
-}
-
-func (Int64) Float64() (float64, bool) {
-	return 0, false
-}
-
-func (Int64) Bool() (bool, bool) {
-	return false, false
-}
-
-func (Int64) getType() entryType {
-	return metaInt64Type
-}
-
-// UInt64 is a uint64 implementing the Entry interface.
-type UInt64 uint64
-
-func (UInt64) String() (string, bool) {
-	return "", false
-}
-
-func (UInt64) Int64() (int64, bool) {
-	return 0, false
-}
-
-func (s UInt64) UInt64() (uint64, bool) {
-	return uint64(s), true
-}
-
-func (UInt64) Float64() (float64, bool) {
-	return 0, false
-}
-
-func (UInt64) Bool() (bool, bool) {
-	return false, false
-}
-
-func (UInt64) getType() entryType {
-	return metaUInt64Type
-}
-
-// Float64 is a float64 implementing the Entry interface.
-type Float64 float64
-
-func (Float64) String() (string, bool) {
-	return "", false
-}
-
-func (Float64) Int64() (int64, bool) {
-	return 0, false
-}
-
-func (Float64) UInt64() (uint64, bool) {
-	return 0, false
-}
-
-func (s Float64) Float64() (float64, bool) {
-	return float64(s), true
-}
-
-func (Float64) Bool() (bool, bool) {
-	return false, false
-}
-
-func (Float64) getType() entryType {
-	return metaFloat64Type
-}
-
-// Bool is a bool implementing the Entry interface.
-type Bool bool
-
-func (Bool) String() (string, bool) {
-	return "", false
-}
-
-func (Bool) Int64() (int64, bool) {
-	return 0, false
-}
-
-func (Bool) UInt64() (uint64, bool) {
-	return 0, false
-}
-
-func (Bool) Float64() (float64, bool) {
-	return 0, false
-}
-
-func (s Bool) Bool() (bool, bool) {
-	return bool(s), true
-}
-
-func (Bool) getType() entryType {
-	return metaBoolType
 }

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1,0 +1,248 @@
+// Package meta provides data types for collectd meta data.
+//
+// Meta data can be associated with value lists (api.ValueList) and
+// notifications (not yet implemented in the collectd Go API).
+package meta
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+type entryType int
+
+const (
+	_ entryType = iota
+	metaStringType
+	metaInt64Type
+	metaUInt64Type
+	metaFloat64Type
+	metaBoolType
+)
+
+// Entry is the interface implemented by all meta data entries. The types
+// implementing this interface are String, Int64, UInt64, Float64 and Bool. The
+// interface contains private functions to prevent other packages from
+// implementing it, so that the use really is limited to the previously listed
+// types.
+type Entry interface {
+	String() (string, bool)
+	Int64() (int64, bool)
+	UInt64() (uint64, bool)
+	Float64() (float64, bool)
+	Bool() (bool, bool)
+
+	getType() entryType
+}
+
+// Data is a map of meta data values. No setter and getter methods are
+// implemented for this, callers are expected to add and remove entries as they
+// would from a normal map.
+type Data map[string]Entry
+
+func (d Data) Clone() Data {
+	if d == nil {
+		return nil
+	}
+
+	cpy := make(Data)
+	for k, v := range d {
+		cpy[k] = v
+	}
+	return cpy
+}
+
+// UnmarshalJSON implements the "encoding/json".Unmarshaller interface.
+func (d *Data) UnmarshalJSON(raw []byte) error {
+	var m map[string]jsonEntry
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return err
+	}
+
+	for k, v := range m {
+		if *d == nil {
+			*d = Data{}
+		}
+		(*d)[k] = v.Entry
+	}
+	return nil
+}
+
+// jsonEntry is a helper type implementing "encoding/json".Unmarshaller for Entry.
+type jsonEntry struct {
+	Entry
+}
+
+func (e *jsonEntry) UnmarshalJSON(raw []byte) error {
+	var b *bool
+	if json.Unmarshal(raw, &b) == nil && b != nil {
+		e.Entry = Bool(*b)
+		return nil
+	}
+
+	var s *string
+	if json.Unmarshal(raw, &s) == nil && s != nil {
+		e.Entry = String(*s)
+		return nil
+	}
+
+	var i *int64
+	if json.Unmarshal(raw, &i) == nil && i != nil {
+		e.Entry = Int64(*i)
+		return nil
+	}
+
+	var u *uint64
+	if json.Unmarshal(raw, &u) == nil && u != nil {
+		e.Entry = UInt64(*u)
+		return nil
+	}
+
+	var f *float64
+	if json.Unmarshal(raw, &f) == nil {
+		if f == nil {
+			nan := math.NaN()
+			f = &nan
+		}
+		e.Entry = Float64(*f)
+		return nil
+	}
+
+	return fmt.Errorf("unable to parse %q as meta entry", raw)
+}
+
+// String is a string implementing the Entry interface.
+type String string
+
+func (s String) String() (string, bool) {
+	return string(s), true
+}
+
+func (String) Int64() (int64, bool) {
+	return 0, false
+}
+
+func (String) UInt64() (uint64, bool) {
+	return 0, false
+}
+
+func (String) Float64() (float64, bool) {
+	return 0, false
+}
+
+func (String) Bool() (bool, bool) {
+	return false, false
+}
+
+func (String) getType() entryType {
+	return metaStringType
+}
+
+// Int64 is a int64 implementing the Entry interface.
+type Int64 int64
+
+func (Int64) String() (string, bool) {
+	return "", false
+}
+
+func (s Int64) Int64() (int64, bool) {
+	return int64(s), true
+}
+
+func (Int64) UInt64() (uint64, bool) {
+	return 0, false
+}
+
+func (Int64) Float64() (float64, bool) {
+	return 0, false
+}
+
+func (Int64) Bool() (bool, bool) {
+	return false, false
+}
+
+func (Int64) getType() entryType {
+	return metaInt64Type
+}
+
+// UInt64 is a uint64 implementing the Entry interface.
+type UInt64 uint64
+
+func (UInt64) String() (string, bool) {
+	return "", false
+}
+
+func (UInt64) Int64() (int64, bool) {
+	return 0, false
+}
+
+func (s UInt64) UInt64() (uint64, bool) {
+	return uint64(s), true
+}
+
+func (UInt64) Float64() (float64, bool) {
+	return 0, false
+}
+
+func (UInt64) Bool() (bool, bool) {
+	return false, false
+}
+
+func (UInt64) getType() entryType {
+	return metaUInt64Type
+}
+
+// Float64 is a float64 implementing the Entry interface.
+type Float64 float64
+
+func (Float64) String() (string, bool) {
+	return "", false
+}
+
+func (Float64) Int64() (int64, bool) {
+	return 0, false
+}
+
+func (Float64) UInt64() (uint64, bool) {
+	return 0, false
+}
+
+func (s Float64) Float64() (float64, bool) {
+	return float64(s), true
+}
+
+func (Float64) Bool() (bool, bool) {
+	return false, false
+}
+
+func (Float64) getType() entryType {
+	return metaFloat64Type
+}
+
+// Bool is a bool implementing the Entry interface.
+type Bool bool
+
+func (Bool) String() (string, bool) {
+	return "", false
+}
+
+func (Bool) Int64() (int64, bool) {
+	return 0, false
+}
+
+func (Bool) UInt64() (uint64, bool) {
+	return 0, false
+}
+
+func (Bool) Float64() (float64, bool) {
+	return 0, false
+}
+
+func (s Bool) Bool() (bool, bool) {
+	return bool(s), true
+}
+
+func (Bool) getType() entryType {
+	return metaBoolType
+}

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -1,0 +1,96 @@
+package meta
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func ExampleData() {
+	// Allocate new meta.Data object.
+	m := make(Data)
+
+	// Add interger named "answer":
+	m["answer"] = Int64(42)
+
+	// Add string named "required":
+	m["required"] = String("towel")
+
+	// Read back a value:
+	answer, ok := m["answer"].Int64()
+	if !ok || answer != 42 {
+		fmt.Printf("m[%q] = (%d, %v), want (%d, %v)", "answer", answer, ok, 42, true)
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Data
+	}{
+		{
+			in:   `{}`,
+			want: nil,
+		},
+		{
+			in:   `{"bool":true}`,
+			want: Data{"bool": Bool(true)},
+		},
+		{
+			in:   `{"string":"bar"}`,
+			want: Data{"string": String("bar")},
+		},
+		{
+			in:   `{"int":42}`,
+			want: Data{"int": Int64(42)},
+		},
+		{ // 9223372036854777144 exceeds 2^63-1
+			in:   `{"uint":9223372036854777144}`,
+			want: Data{"uint": UInt64(9223372036854777144)},
+		},
+		{
+			in:   `{"float":42.25}`,
+			want: Data{"float": Float64(42.25)},
+		},
+		{ // 9223372036854777144 exceeds 2^63-1
+			in: `{"bool":false,"string":"","int":-9223372036854775808,"uint":18446744073709551615,"float":0.00006103515625}`,
+			want: Data{
+				"bool":   Bool(false),
+				"string": String(""),
+				"int":    Int64(-9223372036854775808),
+				"uint":   UInt64(18446744073709551615),
+				"float":  Float64(0.00006103515625),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		var got Data
+		if err := json.Unmarshal([]byte(c.in), &got); err != nil {
+			t.Errorf("Unmarshal() = %v", err)
+			continue
+		}
+
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("Unmarshal() = %#v, want %#v", got, c.want)
+		}
+	}
+}
+
+// TestUnmarshalJSON_NaN tests that null gets converted to Float64(math.NaN()).
+// We cannot add this to the above table test, because reflect.DeepEqual() does
+// not compare two NaNs as equal.
+func TestUnmarshalJSON_NaN(t *testing.T) {
+	var d Data
+	if err := json.Unmarshal([]byte(`{"float":null}`), &d); err != nil {
+		t.Errorf("Unmarshal() = %v", err)
+		return
+	}
+
+	got, ok := d["float"].Float64()
+	if !ok || !math.IsNaN(got) {
+		t.Errorf(`got["float"].Float64() = (%v, %v), want (%v, %v)`, got, ok, math.NaN(), true)
+	}
+}

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -2,7 +2,7 @@ package meta
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 	"math"
 	"reflect"
 	"testing"
@@ -18,10 +18,30 @@ func ExampleData() {
 	// Add string named "required":
 	m["required"] = String("towel")
 
-	// Read back a value:
-	answer, ok := m["answer"].Int64()
-	if !ok || answer != 42 {
-		fmt.Printf("m[%q] = (%d, %v), want (%d, %v)", "answer", answer, ok, 42, true)
+	// Read back a value where you expect a certain type:
+	if v, ok := m["answer"]; ok {
+		answer, ok := v.Int64()
+		if !ok {
+			log.Printf("answer is a %T, expected an Int64", v)
+		}
+		if answer != 42 {
+			log.Printf("answer is a %v, which is obviously wrong", answer)
+		}
+	}
+
+	// Read back a value where you don't know the type:
+	if v, ok := m["required"]; ok {
+		switch v := v.(type) {
+		case String:
+			// here, v is of type String. There are two ways to convert it
+			// to non-interface type:
+			//   * s := string(v)
+			//   * s, ok := v.String()
+			msg := "You need a " + string(v)
+			log.Print(msg)
+		default:
+			log.Printf("You need a %v, but I don't know what that is", v)
+		}
 	}
 }
 

--- a/plugin/c.go
+++ b/plugin/c.go
@@ -8,42 +8,6 @@ package plugin // import "collectd.org/plugin"
 // #include <stdlib.h>
 // #include <dlfcn.h>
 //
-// static int (*register_read_ptr) (char const *group, char const *name,
-//     plugin_read_cb callback,
-//     cdtime_t interval,
-//     user_data_t *ud) = NULL;
-// int register_read_wrapper (char const *group, char const *name,
-//     plugin_read_cb callback,
-//     cdtime_t interval,
-//     user_data_t *ud) {
-//   if (register_read_ptr == NULL) {
-//     void *hnd = dlopen(NULL, RTLD_LAZY);
-//     register_read_ptr = dlsym(hnd, "plugin_register_complex_read");
-//     dlclose(hnd);
-//   }
-//   return (*register_read_ptr) (group, name, callback, interval, ud);
-// }
-//
-// static int (*dispatch_values_ptr) (value_list_t const *vl);
-// int dispatch_values_wrapper (value_list_t const *vl) {
-//   if (dispatch_values_ptr == NULL) {
-//     void *hnd = dlopen(NULL, RTLD_LAZY);
-//     dispatch_values_ptr = dlsym(hnd, "plugin_dispatch_values");
-//     dlclose(hnd);
-//   }
-//   return (*dispatch_values_ptr) (vl);
-// }
-//
-// static cdtime_t (*plugin_get_interval_ptr)(void);
-// cdtime_t plugin_get_interval_wrapper(void) {
-//   if (plugin_get_interval_ptr == NULL) {
-//     void *hnd = dlopen(NULL, RTLD_LAZY);
-//     plugin_get_interval_ptr = dlsym(hnd, "plugin_get_interval");
-//     dlclose(hnd);
-//   }
-//   return (*plugin_get_interval_ptr) ();
-// }
-//
 // void value_list_add (value_list_t *vl, value_t v) {
 //   value_t *tmp = realloc (vl->values, sizeof(v) * (vl->values_len + 1));
 //   if (tmp == NULL) {
@@ -85,37 +49,6 @@ package plugin // import "collectd.org/plugin"
 //
 // derive_t value_list_get_derive (value_list_t *vl, size_t i) {
 //   return vl->values[i].derive;
-// }
-//
-// static int (*register_write_ptr) (char const *, plugin_write_cb, user_data_t *);
-// int register_write_wrapper (char const *name, plugin_write_cb callback, user_data_t *user_data) {
-//   if (register_write_ptr == NULL) {
-//     void *hnd = dlopen(NULL, RTLD_LAZY);
-//     register_write_ptr = dlsym(hnd, "plugin_register_write");
-//     dlclose(hnd);
-//   }
-//   return (*register_write_ptr) (name, callback, user_data);
-// }
-//
-// static int (*register_shutdown_ptr) (char *, plugin_shutdown_cb);
-// int register_shutdown_wrapper (char *name, plugin_shutdown_cb callback) {
-//   if (register_shutdown_ptr == NULL) {
-//     void *hnd = dlopen(NULL, RTLD_LAZY);
-//     register_shutdown_ptr = dlsym(hnd, "plugin_register_shutdown");
-//     dlclose(hnd);
-//   }
-//   return (*register_shutdown_ptr) (name, callback);
-//
-// }
-//
-// static int (*register_log_ptr) (char const *, plugin_log_cb, user_data_t const *);
-// int register_log_wrapper (char const *name, plugin_log_cb callback, user_data_t const *user_data) {
-//   if (register_log_ptr == NULL) {
-//     void *hnd = dlopen(NULL, RTLD_LAZY);
-//     register_log_ptr = dlsym(hnd, "plugin_register_log");
-//     dlclose(hnd);
-//   }
-//   return (*register_log_ptr) (name, callback, user_data);
 // }
 //
 // static int *timeout_ptr;

--- a/plugin/fake/meta_data.c
+++ b/plugin/fake/meta_data.c
@@ -1,0 +1,487 @@
+/**
+ * collectd - src/meta_data.c
+ * Copyright (C) 2008-2011  Florian octo Forster
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *   Florian octo Forster <octo at collectd.org>
+ **/
+
+#include "collectd.h"
+#include "plugin.h"
+
+#include <stdbool.h>
+
+#define MD_MAX_NONSTRING_CHARS 128
+
+/*
+ * Data types
+ */
+union meta_value_u {
+  char *mv_string;
+  int64_t mv_signed_int;
+  uint64_t mv_unsigned_int;
+  double mv_double;
+  bool mv_boolean;
+};
+typedef union meta_value_u meta_value_t;
+
+struct meta_entry_s;
+typedef struct meta_entry_s meta_entry_t;
+struct meta_entry_s {
+  char *key;
+  meta_value_t value;
+  int type;
+  meta_entry_t *next;
+};
+
+struct meta_data_s {
+  meta_entry_t *head;
+  pthread_mutex_t lock;
+};
+
+/*
+ * Private functions
+ */
+static meta_entry_t *md_entry_alloc(const char *key) /* {{{ */
+{
+  meta_entry_t *e;
+
+  e = calloc(1, sizeof(*e));
+  if (e == NULL) {
+    ERROR("md_entry_alloc: calloc failed.");
+    return NULL;
+  }
+
+  e->key = strdup(key);
+  if (e->key == NULL) {
+    free(e);
+    ERROR("md_entry_alloc: strdup failed.");
+    return NULL;
+  }
+
+  e->type = 0;
+  e->next = NULL;
+
+  return e;
+} /* }}} meta_entry_t *md_entry_alloc */
+
+static void md_entry_free(meta_entry_t *e) /* {{{ */
+{
+  if (e == NULL)
+    return;
+
+  free(e->key);
+
+  if (e->type == MD_TYPE_STRING)
+    free(e->value.mv_string);
+
+  if (e->next != NULL)
+    md_entry_free(e->next);
+
+  free(e);
+} /* }}} void md_entry_free */
+
+static int md_entry_insert(meta_data_t *md, meta_entry_t *e) /* {{{ */
+{
+  meta_entry_t *this;
+  meta_entry_t *prev;
+
+  if ((md == NULL) || (e == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  prev = NULL;
+  this = md->head;
+  while (this != NULL) {
+    if (strcasecmp(e->key, this->key) == 0)
+      break;
+
+    prev = this;
+    this = this->next;
+  }
+
+  if (this == NULL) {
+    /* This key does not exist yet. */
+    if (md->head == NULL)
+      md->head = e;
+    else {
+      assert(prev != NULL);
+      prev->next = e;
+    }
+
+    e->next = NULL;
+  } else /* (this != NULL) */
+  {
+    if (prev == NULL)
+      md->head = e;
+    else
+      prev->next = e;
+
+    e->next = this->next;
+  }
+
+  pthread_mutex_unlock(&md->lock);
+
+  if (this != NULL) {
+    this->next = NULL;
+    md_entry_free(this);
+  }
+
+  return 0;
+} /* }}} int md_entry_insert */
+
+/* XXX: The lock on md must be held while calling this function! */
+static meta_entry_t *md_entry_lookup(meta_data_t *md, /* {{{ */
+                                     const char *key) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL))
+    return NULL;
+
+  for (e = md->head; e != NULL; e = e->next)
+    if (strcasecmp(key, e->key) == 0)
+      break;
+
+  return e;
+} /* }}} meta_entry_t *md_entry_lookup */
+
+/*
+ * Each value_list_t*, as it is going through the system, is handled by exactly
+ * one thread. Plugins which pass a value_list_t* to another thread, e.g. the
+ * rrdtool plugin, must create a copy first. The meta data within a
+ * value_list_t* is not thread safe and doesn't need to be.
+ *
+ * The meta data associated with cache entries are a different story. There, we
+ * need to ensure exclusive locking to prevent leaks and other funky business.
+ * This is ensured by the uc_meta_data_get_*() functions.
+ */
+
+/*
+ * Public functions
+ */
+meta_data_t *meta_data_create(void) /* {{{ */
+{
+  meta_data_t *md;
+
+  md = calloc(1, sizeof(*md));
+  if (md == NULL) {
+    ERROR("meta_data_create: calloc failed.");
+    return NULL;
+  }
+
+  pthread_mutex_init(&md->lock, /* attr = */ NULL);
+
+  return md;
+} /* }}} meta_data_t *meta_data_create */
+
+void meta_data_destroy(meta_data_t *md) /* {{{ */
+{
+  if (md == NULL)
+    return;
+
+  md_entry_free(md->head);
+  pthread_mutex_destroy(&md->lock);
+  free(md);
+} /* }}} void meta_data_destroy */
+
+int meta_data_type(meta_data_t *md, const char *key) /* {{{ */
+{
+  if ((md == NULL) || (key == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  for (meta_entry_t *e = md->head; e != NULL; e = e->next) {
+    if (strcasecmp(key, e->key) == 0) {
+      pthread_mutex_unlock(&md->lock);
+      return e->type;
+    }
+  }
+
+  pthread_mutex_unlock(&md->lock);
+  return 0;
+} /* }}} int meta_data_type */
+
+int meta_data_toc(meta_data_t *md, char ***toc) /* {{{ */
+{
+  int i = 0, count = 0;
+
+  if ((md == NULL) || (toc == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  for (meta_entry_t *e = md->head; e != NULL; e = e->next)
+    ++count;
+
+  if (count == 0) {
+    pthread_mutex_unlock(&md->lock);
+    return count;
+  }
+
+  *toc = calloc(count, sizeof(**toc));
+  for (meta_entry_t *e = md->head; e != NULL; e = e->next)
+    (*toc)[i++] = strdup(e->key);
+
+  pthread_mutex_unlock(&md->lock);
+  return count;
+} /* }}} int meta_data_toc */
+
+/*
+ * Add functions
+ */
+int meta_data_add_string(meta_data_t *md, /* {{{ */
+                         const char *key, const char *value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL) || (value == NULL))
+    return -EINVAL;
+
+  e = md_entry_alloc(key);
+  if (e == NULL)
+    return -ENOMEM;
+
+  e->value.mv_string = strdup(value);
+  if (e->value.mv_string == NULL) {
+    ERROR("meta_data_add_string: strdup failed.");
+    md_entry_free(e);
+    return -ENOMEM;
+  }
+  e->type = MD_TYPE_STRING;
+
+  return md_entry_insert(md, e);
+} /* }}} int meta_data_add_string */
+
+int meta_data_add_signed_int(meta_data_t *md, /* {{{ */
+                             const char *key, int64_t value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL))
+    return -EINVAL;
+
+  e = md_entry_alloc(key);
+  if (e == NULL)
+    return -ENOMEM;
+
+  e->value.mv_signed_int = value;
+  e->type = MD_TYPE_SIGNED_INT;
+
+  return md_entry_insert(md, e);
+} /* }}} int meta_data_add_signed_int */
+
+int meta_data_add_unsigned_int(meta_data_t *md, /* {{{ */
+                               const char *key, uint64_t value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL))
+    return -EINVAL;
+
+  e = md_entry_alloc(key);
+  if (e == NULL)
+    return -ENOMEM;
+
+  e->value.mv_unsigned_int = value;
+  e->type = MD_TYPE_UNSIGNED_INT;
+
+  return md_entry_insert(md, e);
+} /* }}} int meta_data_add_unsigned_int */
+
+int meta_data_add_double(meta_data_t *md, /* {{{ */
+                         const char *key, double value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL))
+    return -EINVAL;
+
+  e = md_entry_alloc(key);
+  if (e == NULL)
+    return -ENOMEM;
+
+  e->value.mv_double = value;
+  e->type = MD_TYPE_DOUBLE;
+
+  return md_entry_insert(md, e);
+} /* }}} int meta_data_add_double */
+
+int meta_data_add_boolean(meta_data_t *md, /* {{{ */
+                          const char *key, bool value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL))
+    return -EINVAL;
+
+  e = md_entry_alloc(key);
+  if (e == NULL)
+    return -ENOMEM;
+
+  e->value.mv_boolean = value;
+  e->type = MD_TYPE_BOOLEAN;
+
+  return md_entry_insert(md, e);
+} /* }}} int meta_data_add_boolean */
+
+/*
+ * Get functions
+ */
+int meta_data_get_string(meta_data_t *md, /* {{{ */
+                         const char *key, char **value) {
+  meta_entry_t *e;
+  char *temp;
+
+  if ((md == NULL) || (key == NULL) || (value == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  e = md_entry_lookup(md, key);
+  if (e == NULL) {
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  if (e->type != MD_TYPE_STRING) {
+    ERROR("meta_data_get_string: Type mismatch for key `%s'", e->key);
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  temp = strdup(e->value.mv_string);
+  if (temp == NULL) {
+    pthread_mutex_unlock(&md->lock);
+    ERROR("meta_data_get_string: strdup failed.");
+    return -ENOMEM;
+  }
+
+  pthread_mutex_unlock(&md->lock);
+
+  *value = temp;
+
+  return 0;
+} /* }}} int meta_data_get_string */
+
+int meta_data_get_signed_int(meta_data_t *md, /* {{{ */
+                             const char *key, int64_t *value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL) || (value == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  e = md_entry_lookup(md, key);
+  if (e == NULL) {
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  if (e->type != MD_TYPE_SIGNED_INT) {
+    ERROR("meta_data_get_signed_int: Type mismatch for key `%s'", e->key);
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  *value = e->value.mv_signed_int;
+
+  pthread_mutex_unlock(&md->lock);
+  return 0;
+} /* }}} int meta_data_get_signed_int */
+
+int meta_data_get_unsigned_int(meta_data_t *md, /* {{{ */
+                               const char *key, uint64_t *value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL) || (value == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  e = md_entry_lookup(md, key);
+  if (e == NULL) {
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  if (e->type != MD_TYPE_UNSIGNED_INT) {
+    ERROR("meta_data_get_unsigned_int: Type mismatch for key `%s'", e->key);
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  *value = e->value.mv_unsigned_int;
+
+  pthread_mutex_unlock(&md->lock);
+  return 0;
+} /* }}} int meta_data_get_unsigned_int */
+
+int meta_data_get_double(meta_data_t *md, /* {{{ */
+                         const char *key, double *value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL) || (value == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  e = md_entry_lookup(md, key);
+  if (e == NULL) {
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  if (e->type != MD_TYPE_DOUBLE) {
+    ERROR("meta_data_get_double: Type mismatch for key `%s'", e->key);
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  *value = e->value.mv_double;
+
+  pthread_mutex_unlock(&md->lock);
+  return 0;
+} /* }}} int meta_data_get_double */
+
+int meta_data_get_boolean(meta_data_t *md, /* {{{ */
+                          const char *key, bool *value) {
+  meta_entry_t *e;
+
+  if ((md == NULL) || (key == NULL) || (value == NULL))
+    return -EINVAL;
+
+  pthread_mutex_lock(&md->lock);
+
+  e = md_entry_lookup(md, key);
+  if (e == NULL) {
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  if (e->type != MD_TYPE_BOOLEAN) {
+    ERROR("meta_data_get_boolean: Type mismatch for key `%s'", e->key);
+    pthread_mutex_unlock(&md->lock);
+    return -ENOENT;
+  }
+
+  *value = e->value.mv_boolean;
+
+  pthread_mutex_unlock(&md->lock);
+  return 0;
+} /* }}} int meta_data_get_boolean */

--- a/plugin/generator/generator.go
+++ b/plugin/generator/generator.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"bytes"
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"text/template"
+)
+
+var functions = []Function{
+	{
+		Name: "plugin_register_complex_read",
+		Args: []Argument{
+			{"group", "meta_data_t *"},
+			{"name", "char const *"},
+			{"callback", "plugin_read_cb"},
+			{"interval", "cdtime_t"},
+			{"ud", "user_data_t *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "plugin_register_write",
+		Args: []Argument{
+			{"name", "char const *"},
+			{"callback", "plugin_write_cb"},
+			{"ud", "user_data_t *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "plugin_register_shutdown",
+		Args: []Argument{
+			{"name", "char const *"},
+			{"callback", "plugin_shutdown_cb"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "plugin_register_log",
+		Args: []Argument{
+			{"name", "char const *"},
+			{"callback", "plugin_log_cb"},
+			{"ud", "user_data_t *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "plugin_dispatch_values",
+		Args: []Argument{
+			{"vl", "value_list_t const *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "plugin_get_interval",
+		Ret:  "cdtime_t",
+	},
+	{
+		Name: "meta_data_create",
+		Ret:  "meta_data_t *",
+	},
+	{
+		Name: "meta_data_destroy",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+		},
+		Ret: "void",
+	},
+	{
+		Name: "meta_data_toc",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"toc", "char ***"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_type",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_add_boolean",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "bool"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_add_double",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "double"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_add_signed_int",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "int64_t"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_add_unsigned_int",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "uint64_t"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_add_string",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "char const *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_get_boolean",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "bool *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_get_double",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "double *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_get_signed_int",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "int64_t *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_get_unsigned_int",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "uint64_t *"},
+		},
+		Ret: "int",
+	},
+	{
+		Name: "meta_data_get_string",
+		Args: []Argument{
+			{"md", "meta_data_t *"},
+			{"key", "char const *"},
+			{"value", "char **"},
+		},
+		Ret: "int",
+	},
+}
+
+const ptrTmpl = "static {{.Ret}} (*{{.Name}}_ptr)({{.ArgsTypes}});\n"
+
+const wrapperTmpl = `{{.Ret}} {{.Name}}_wrapper({{.ArgsStr}}) {
+	LOAD({{.Name}});
+	{{if not .IsVoid}}return {{end}}(*{{.Name}}_ptr)({{.ArgsNames}});
+}
+
+`
+
+type Argument struct {
+	Name string
+	Type string
+}
+
+func (a Argument) String() string {
+	return a.Type + " " + a.Name
+}
+
+type Function struct {
+	Name string
+	Args []Argument
+	Ret  string
+}
+
+func (f Function) ArgsTypes() string {
+	if len(f.Args) == 0 {
+		return "void"
+	}
+
+	var args []string
+	for _, a := range f.Args {
+		args = append(args, a.Type)
+	}
+
+	return strings.Join(args, ", ")
+}
+
+func (f Function) ArgsNames() string {
+	var args []string
+	for _, a := range f.Args {
+		args = append(args, a.Name)
+	}
+
+	return strings.Join(args, ", ")
+}
+
+func (f Function) ArgsStr() string {
+	if len(f.Args) == 0 {
+		return "void"
+	}
+
+	var args []string
+	for _, a := range f.Args {
+		args = append(args, a.String())
+	}
+
+	return strings.Join(args, ", ")
+}
+
+func (f Function) IsVoid() bool {
+	return f.Ret == "void"
+}
+
+type byName []Function
+
+func (f byName) Len() int           { return len(f) }
+func (f byName) Less(i, j int) bool { return f[i].Name < f[j].Name }
+func (f byName) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
+
+func main() {
+	var rawC bytes.Buffer
+	fmt.Fprint(&rawC, `#include "plugin.h"
+#include <stdlib.h>
+#include <stdbool.h>
+#include <dlfcn.h>
+
+#define LOAD(f)                                                             \
+  if (f##_ptr == NULL) {                                                    \
+    void *hnd = dlopen(NULL, RTLD_LAZY);                                    \
+    f##_ptr = dlsym(hnd, #f);                                               \
+    dlclose(hnd);                                                           \
+  }
+
+`)
+
+	sort.Sort(byName(functions))
+
+	t, err := template.New("ptr").Parse(ptrTmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, f := range functions {
+		if err := t.Execute(&rawC, f); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	fmt.Fprintln(&rawC)
+
+	t, err = template.New("wrapper").Parse(wrapperTmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, f := range functions {
+		if err := t.Execute(&rawC, f); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	var fmtC bytes.Buffer
+
+	cmd := exec.Command("clang-format")
+	cmd.Stdin = &rawC
+	cmd.Stdout = &fmtC
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print(`// +build go1.5,cgo
+
+package plugin // import "collectd.org/plugin"
+
+// #cgo CPPFLAGS: -DHAVE_CONFIG_H
+// #cgo LDFLAGS: -ldl
+`)
+	s := bufio.NewScanner(&fmtC)
+	for s.Scan() {
+		fmt.Println("//", s.Text())
+	}
+	fmt.Println(`import "C"`)
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -74,6 +74,7 @@ package plugin // import "collectd.org/plugin"
 // #cgo CPPFLAGS: -DHAVE_CONFIG_H
 // #cgo LDFLAGS: -ldl
 // #include <stdlib.h>
+// #include <stdbool.h>
 // #include <dlfcn.h>
 // #include "plugin.h"
 //
@@ -89,6 +90,21 @@ package plugin // import "collectd.org/plugin"
 // counter_t value_list_get_counter (value_list_t *, size_t);
 // derive_t  value_list_get_derive  (value_list_t *, size_t);
 // gauge_t   value_list_get_gauge   (value_list_t *, size_t);
+//
+// meta_data_t *meta_data_create_wrapper(void);
+// void meta_data_destroy_wrapper(meta_data_t *md);
+// int meta_data_add_boolean_wrapper(meta_data_t *md, const char *key, bool value);
+// int meta_data_add_double_wrapper(meta_data_t *md, const char *key, double value);
+// int meta_data_add_signed_int_wrapper(meta_data_t *md, const char *key, int64_t value);
+// int meta_data_add_string_wrapper(meta_data_t *md, const char *key, const char *value);
+// int meta_data_add_unsigned_int_wrapper(meta_data_t *md, const char *key, uint64_t value);
+// int meta_data_get_boolean_wrapper(meta_data_t *md, const char *key, bool *value);
+// int meta_data_get_double_wrapper(meta_data_t *md, const char *key, double *value);
+// int meta_data_get_signed_int_wrapper(meta_data_t *md, const char *key, int64_t *value);
+// int meta_data_get_string_wrapper(meta_data_t *md, const char *key, char **value);
+// int meta_data_get_unsigned_int_wrapper(meta_data_t *md, const char *key, uint64_t *value);
+// int meta_data_toc_wrapper(meta_data_t *md, char ***toc);
+// int meta_data_type_wrapper(meta_data_t *md, char const *key);
 //
 // int plugin_register_complex_read_wrapper(char const *group, char const *name,
 //                                          plugin_read_cb callback,
@@ -117,6 +133,7 @@ import (
 
 	"collectd.org/api"
 	"collectd.org/cdtime"
+	"collectd.org/meta"
 )
 
 // Reader defines the interface for read callbacks, i.e. Go functions that are
@@ -170,7 +187,160 @@ func newValueListT(vl *api.ValueList) (*C.value_list_t, error) {
 		}
 	}
 
+	md, err := marshalMeta(vl.Meta)
+	if err != nil {
+		return nil, err
+	}
+	ret.meta = md
+
 	return ret, nil
+}
+
+func freeValueListT(vl *C.value_list_t) {
+	C.free(unsafe.Pointer(vl.values))
+	vl.values = nil
+	if vl.meta != nil {
+		C.meta_data_destroy_wrapper(vl.meta)
+		vl.meta = nil
+	}
+}
+
+func marshalMeta(meta meta.Data) (*C.meta_data_t, error) {
+	if meta == nil {
+		return nil, nil
+	}
+
+	md, err := C.meta_data_create_wrapper()
+	if err != nil {
+		return nil, wrapCError(0, err, "meta_data_create")
+	}
+
+	for k, v := range meta {
+		if err := marshalMetaEntry(md, k, v); err != nil {
+			C.meta_data_destroy_wrapper(md)
+			return nil, err
+		}
+	}
+
+	return md, nil
+}
+
+func marshalMetaEntry(md *C.meta_data_t, key string, value meta.Entry) error {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	switch value := value.Interface().(type) {
+	case bool:
+		s, err := C.meta_data_add_boolean_wrapper(md, cKey, C.bool(value))
+		return wrapCError(s, err, "meta_data_add_boolean")
+	case float64:
+		s, err := C.meta_data_add_double_wrapper(md, cKey, C.double(value))
+		return wrapCError(s, err, "meta_data_add_double")
+	case int64:
+		s, err := C.meta_data_add_signed_int_wrapper(md, cKey, C.int64_t(value))
+		return wrapCError(s, err, "meta_data_add_signed_int")
+	case uint64:
+		s, err := C.meta_data_add_unsigned_int_wrapper(md, cKey, C.uint64_t(value))
+		return wrapCError(s, err, "meta_data_add_unsigned_int")
+	case string:
+		cValue := C.CString(value)
+		defer C.free(unsafe.Pointer(cValue))
+		s, err := C.meta_data_add_string_wrapper(md, cKey, cValue)
+		return wrapCError(s, err, "meta_data_add_string")
+	default:
+		return nil
+	}
+}
+
+// cStrarrayIndex returns the n'th string in the array, i.e. strings[n].
+func cStrarrayIndex(strings **C.char, n int) *C.char {
+	offset := uintptr(n) * unsafe.Sizeof(*strings)
+	ptr := (**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(strings)) + offset))
+	return *ptr
+}
+
+func unmarshalMeta(md *C.meta_data_t) (meta.Data, error) {
+	if md == nil {
+		return nil, nil
+	}
+
+	var ptr **C.char
+	num, err := C.meta_data_toc_wrapper(md, &ptr)
+	if num < 0 || err != nil {
+		return nil, wrapCError(num, err, "meta_data_toc")
+	}
+	if num < 1 {
+		return nil, nil
+	}
+	defer func() {
+		for i := 0; i < int(num); i++ {
+			C.free(unsafe.Pointer(cStrarrayIndex(ptr, i)))
+		}
+		C.free(unsafe.Pointer(ptr))
+	}()
+
+	ret := make(meta.Data)
+	for i := 0; i < int(num); i++ {
+		key := cStrarrayIndex(ptr, i)
+		if err := unmarshalMetaEntry(ret, md, key); err != nil {
+			return nil, err
+		}
+	}
+
+	return ret, nil
+}
+
+func unmarshalMetaEntry(goMeta meta.Data, cMeta *C.meta_data_t, key *C.char) error {
+	typ, err := C.meta_data_type_wrapper(cMeta, key)
+	if typ <= 0 || err != nil {
+		if typ == 0 && err == nil {
+			err = fmt.Errorf("no such meta data key: %q", C.GoString(key))
+		}
+		return wrapCError(0, err, "meta_data_type")
+	}
+
+	switch typ {
+	case C.MD_TYPE_BOOLEAN:
+		var v C.bool
+		s, err := C.meta_data_get_boolean_wrapper(cMeta, key, &v)
+		if err := wrapCError(s, err, "meta_data_get_boolean"); err != nil {
+			return err
+		}
+		goMeta[C.GoString(key)] = meta.Bool(bool(v))
+	case C.MD_TYPE_DOUBLE:
+		var v C.double
+		s, err := C.meta_data_get_double_wrapper(cMeta, key, &v)
+		if err := wrapCError(s, err, "meta_data_get_double"); err != nil {
+			return err
+		}
+		goMeta[C.GoString(key)] = meta.Float64(float64(v))
+	case C.MD_TYPE_SIGNED_INT:
+		var v C.int64_t
+		s, err := C.meta_data_get_signed_int_wrapper(cMeta, key, &v)
+		if err := wrapCError(s, err, "meta_data_get_signed_int"); err != nil {
+			return err
+		}
+		goMeta[C.GoString(key)] = meta.Int64(int64(v))
+	case C.MD_TYPE_STRING:
+		var v *C.char
+		s, err := C.meta_data_get_string_wrapper(cMeta, key, &v)
+		if err := wrapCError(s, err, "meta_data_get_string"); err != nil {
+			return err
+		}
+		defer C.free(unsafe.Pointer(v))
+		goMeta[C.GoString(key)] = meta.String(C.GoString(v))
+	case C.MD_TYPE_UNSIGNED_INT:
+		var v C.uint64_t
+		s, err := C.meta_data_get_unsigned_int_wrapper(cMeta, key, &v)
+		if err := wrapCError(s, err, "meta_data_get_unsigned_int"); err != nil {
+			return err
+		}
+		goMeta[C.GoString(key)] = meta.UInt64(uint64(v))
+	default:
+		Warningf("unexpected meta data type %v", typ)
+	}
+
+	return nil
 }
 
 // Write converts a ValueList and calls the plugin_dispatch_values() function
@@ -208,7 +378,7 @@ func Write(ctx context.Context, vl *api.ValueList) error {
 	if err != nil {
 		return err
 	}
-	defer C.free(unsafe.Pointer(vlt.values))
+	defer freeValueListT(vlt)
 
 	status, err := C.plugin_dispatch_values_wrapper(vlt)
 	return wrapCError(status, err, "plugin_dispatch_values")
@@ -376,6 +546,12 @@ func wrap_write_callback(ds *C.data_set_t, cvl *C.value_list_t, ud *C.user_data_
 
 		vl.DSNames = append(vl.DSNames, C.GoString(&dsrc.name[0]))
 	}
+
+	m, err := unmarshalMeta(cvl.meta)
+	if err != nil {
+		Errorf("%s plugin: unmarshalMeta() failed: %v", name, err)
+	}
+	vl.Meta = m
 
 	ctx := withName(context.Background(), name)
 	if err := w.Write(ctx, vl); err != nil {

--- a/plugin/wrapper.go
+++ b/plugin/wrapper.go
@@ -1,0 +1,164 @@
+// +build go1.5,cgo
+
+package plugin // import "collectd.org/plugin"
+
+// #cgo CPPFLAGS: -DHAVE_CONFIG_H
+// #cgo LDFLAGS: -ldl
+// #include "plugin.h"
+// #include <dlfcn.h>
+// #include <stdbool.h>
+// #include <stdlib.h>
+//
+// #define LOAD(f)                                                                \
+//   if (f##_ptr == NULL) {                                                       \
+//     void *hnd = dlopen(NULL, RTLD_LAZY);                                       \
+//     f##_ptr = dlsym(hnd, #f);                                                  \
+//     dlclose(hnd);                                                              \
+//   }
+//
+// static int (*meta_data_add_boolean_ptr)(meta_data_t *, char const *, bool);
+// static int (*meta_data_add_double_ptr)(meta_data_t *, char const *, double);
+// static int (*meta_data_add_signed_int_ptr)(meta_data_t *, char const *,
+//                                            int64_t);
+// static int (*meta_data_add_string_ptr)(meta_data_t *, char const *,
+//                                        char const *);
+// static int (*meta_data_add_unsigned_int_ptr)(meta_data_t *, char const *,
+//                                              uint64_t);
+// static meta_data_t *(*meta_data_create_ptr)(void);
+// static void (*meta_data_destroy_ptr)(meta_data_t *);
+// static int (*meta_data_get_boolean_ptr)(meta_data_t *, char const *, bool *);
+// static int (*meta_data_get_double_ptr)(meta_data_t *, char const *, double *);
+// static int (*meta_data_get_signed_int_ptr)(meta_data_t *, char const *,
+//                                            int64_t *);
+// static int (*meta_data_get_string_ptr)(meta_data_t *, char const *, char **);
+// static int (*meta_data_get_unsigned_int_ptr)(meta_data_t *, char const *,
+//                                              uint64_t *);
+// static int (*meta_data_toc_ptr)(meta_data_t *, char ***);
+// static int (*meta_data_type_ptr)(meta_data_t *, char const *);
+// static int (*plugin_dispatch_values_ptr)(value_list_t const *);
+// static cdtime_t (*plugin_get_interval_ptr)(void);
+// static int (*plugin_register_complex_read_ptr)(meta_data_t *, char const *,
+//                                                plugin_read_cb, cdtime_t,
+//                                                user_data_t *);
+// static int (*plugin_register_log_ptr)(char const *, plugin_log_cb,
+//                                       user_data_t *);
+// static int (*plugin_register_shutdown_ptr)(char const *, plugin_shutdown_cb);
+// static int (*plugin_register_write_ptr)(char const *, plugin_write_cb,
+//                                         user_data_t *);
+//
+// int meta_data_add_boolean_wrapper(meta_data_t *md, char const *key,
+//                                   bool value) {
+//   LOAD(meta_data_add_boolean);
+//   return (*meta_data_add_boolean_ptr)(md, key, value);
+// }
+//
+// int meta_data_add_double_wrapper(meta_data_t *md, char const *key,
+//                                  double value) {
+//   LOAD(meta_data_add_double);
+//   return (*meta_data_add_double_ptr)(md, key, value);
+// }
+//
+// int meta_data_add_signed_int_wrapper(meta_data_t *md, char const *key,
+//                                      int64_t value) {
+//   LOAD(meta_data_add_signed_int);
+//   return (*meta_data_add_signed_int_ptr)(md, key, value);
+// }
+//
+// int meta_data_add_string_wrapper(meta_data_t *md, char const *key,
+//                                  char const *value) {
+//   LOAD(meta_data_add_string);
+//   return (*meta_data_add_string_ptr)(md, key, value);
+// }
+//
+// int meta_data_add_unsigned_int_wrapper(meta_data_t *md, char const *key,
+//                                        uint64_t value) {
+//   LOAD(meta_data_add_unsigned_int);
+//   return (*meta_data_add_unsigned_int_ptr)(md, key, value);
+// }
+//
+// meta_data_t *meta_data_create_wrapper(void) {
+//   LOAD(meta_data_create);
+//   return (*meta_data_create_ptr)();
+// }
+//
+// void meta_data_destroy_wrapper(meta_data_t *md) {
+//   LOAD(meta_data_destroy);
+//   (*meta_data_destroy_ptr)(md);
+// }
+//
+// int meta_data_get_boolean_wrapper(meta_data_t *md, char const *key,
+//                                   bool *value) {
+//   LOAD(meta_data_get_boolean);
+//   return (*meta_data_get_boolean_ptr)(md, key, value);
+// }
+//
+// int meta_data_get_double_wrapper(meta_data_t *md, char const *key,
+//                                  double *value) {
+//   LOAD(meta_data_get_double);
+//   return (*meta_data_get_double_ptr)(md, key, value);
+// }
+//
+// int meta_data_get_signed_int_wrapper(meta_data_t *md, char const *key,
+//                                      int64_t *value) {
+//   LOAD(meta_data_get_signed_int);
+//   return (*meta_data_get_signed_int_ptr)(md, key, value);
+// }
+//
+// int meta_data_get_string_wrapper(meta_data_t *md, char const *key,
+//                                  char **value) {
+//   LOAD(meta_data_get_string);
+//   return (*meta_data_get_string_ptr)(md, key, value);
+// }
+//
+// int meta_data_get_unsigned_int_wrapper(meta_data_t *md, char const *key,
+//                                        uint64_t *value) {
+//   LOAD(meta_data_get_unsigned_int);
+//   return (*meta_data_get_unsigned_int_ptr)(md, key, value);
+// }
+//
+// int meta_data_toc_wrapper(meta_data_t *md, char ***toc) {
+//   LOAD(meta_data_toc);
+//   return (*meta_data_toc_ptr)(md, toc);
+// }
+//
+// int meta_data_type_wrapper(meta_data_t *md, char const *key) {
+//   LOAD(meta_data_type);
+//   return (*meta_data_type_ptr)(md, key);
+// }
+//
+// int plugin_dispatch_values_wrapper(value_list_t const *vl) {
+//   LOAD(plugin_dispatch_values);
+//   return (*plugin_dispatch_values_ptr)(vl);
+// }
+//
+// cdtime_t plugin_get_interval_wrapper(void) {
+//   LOAD(plugin_get_interval);
+//   return (*plugin_get_interval_ptr)();
+// }
+//
+// int plugin_register_complex_read_wrapper(meta_data_t *group, char const *name,
+//                                          plugin_read_cb callback,
+//                                          cdtime_t interval, user_data_t *ud) {
+//   LOAD(plugin_register_complex_read);
+//   return (*plugin_register_complex_read_ptr)(group, name, callback, interval,
+//                                              ud);
+// }
+//
+// int plugin_register_log_wrapper(char const *name, plugin_log_cb callback,
+//                                 user_data_t *ud) {
+//   LOAD(plugin_register_log);
+//   return (*plugin_register_log_ptr)(name, callback, ud);
+// }
+//
+// int plugin_register_shutdown_wrapper(char const *name,
+//                                      plugin_shutdown_cb callback) {
+//   LOAD(plugin_register_shutdown);
+//   return (*plugin_register_shutdown_ptr)(name, callback);
+// }
+//
+// int plugin_register_write_wrapper(char const *name, plugin_write_cb callback,
+//                                   user_data_t *ud) {
+//   LOAD(plugin_register_write);
+//   return (*plugin_register_write_ptr)(name, callback, ud);
+// }
+import "C"


### PR DESCRIPTION
Meta data entries are essentially a union of a couple different types. There are multiple ways to achieve something union-like in Go and this PR is taking a relatively type save approach.

There is a usage example in `meta_test.go` which hopefully illustrates how this package is supposed to be used. I added a Meta field to api.ValueList and plumbed that field through the JSON marshalling. 

CC: @davegalos