### PR TITLE
Full new implementation of api.ValueList metadata

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -85,6 +85,7 @@ type ValueList struct {
 	Interval time.Duration
 	Values   []Value
 	DSNames  []string
+	Metadata Metadata
 }
 
 // DSName returns the name of the data source at the given index. If vl.DSNames

--- a/api/meta.go
+++ b/api/meta.go
@@ -1,0 +1,98 @@
+// Package api defines data types representing core collectd data types.
+package api // import "collectd.org/api"
+
+// Author: Remi Ferrand <remi.ferrand_at_cc.in2p3.fr>
+
+import (
+	"sort"
+	"strconv"
+)
+
+// Metadata represents a ValueList metadata. It's Go's equivalent to the
+// linked list `meta_data_s`
+// Currently only int64, uint64, float64, string and bool metadata
+// types are supported
+type Metadata map[string]interface{}
+
+// Get fetches metadata associated with `key`
+func (m Metadata) Get(key string) interface{} {
+	return m[key]
+}
+
+// GetAsString returns the value as a string, regardless of the type
+// It's Go's equivalent to the `meta_data_as_string` function
+func (m Metadata) GetAsString(key string) string {
+	v := m.Get(key)
+
+	switch v.(type) {
+	case int64:
+		return strconv.FormatInt(v.(int64), 10)
+	case uint64:
+		return strconv.FormatUint(v.(uint64), 10)
+	case float64:
+		return strconv.FormatFloat(v.(float64), 'e', 5, 64)
+	case bool:
+		return strconv.FormatBool(v.(bool))
+	case string:
+		return v.(string)
+	default:
+		panic("unsupported type")
+	}
+}
+
+// Set adds a new metadata
+// If `key` is already present, old value will
+// be overwritten
+func (m *Metadata) Set(key string, value interface{}) {
+	(*m)[key] = value
+}
+
+// Delete removes metadata associated with `key`
+func (m *Metadata) Delete(key string) {
+	delete(*m, key)
+}
+
+// Exists checks if a given metadata key exists
+func (m Metadata) Exists(key string) bool {
+	for k := range m {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// Toc returns all the metadata keys
+// keys will always be sorted using Go
+// sort.Strings() function
+func (m Metadata) Toc() []string {
+	keys := make([]string, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Clone returns a cloned copy of the Metadata
+func (m Metadata) Clone() Metadata {
+	nMeta := make(Metadata)
+	for k := range m {
+		nMeta.Set(k, m.Get(k))
+	}
+	return nMeta
+}
+
+// CloneMerge merges data metadata from `orig`
+// into a cloned copy of the current Metadata object
+// If a key exists both in the current Metadata object
+// and in `orig`, the key from `orig` will be kept
+func (m Metadata) CloneMerge(orig Metadata) Metadata {
+	nMeta := m.Clone()
+	for k := range orig {
+		nMeta[k] = orig.Get(k)
+	}
+	return nMeta
+}

--- a/api/meta_test.go
+++ b/api/meta_test.go
@@ -1,0 +1,84 @@
+package api
+
+// Author: Remi Ferrand <remi.ferrand_at_cc.in2p3.fr>
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMetadataGetAsString(t *testing.T) {
+	t.Parallel()
+
+	meta := make(Metadata)
+	meta.Set("int_value", int64(-42))
+	meta.Set("bool_value", true)
+	meta.Set("str_value", "hello")
+	meta.Set("uint_value", uint64(42))
+	meta.Set("float_value", float64(42.0))
+
+	testCases := []struct {
+		Key      string
+		Expected string
+	}{
+		{"int_value", "-42"},
+		{"bool_value", "true"},
+		{"str_value", "hello"},
+		{"uint_value", "42"},
+		{"float_value", "4.20000e+01"},
+	}
+
+	for _, testCase := range testCases {
+		asString := meta.GetAsString(testCase.Key)
+		if asString != testCase.Expected {
+			t.Errorf("with key '%s', got '%s' while '%s' was expected",
+				testCase.Key, asString, testCase.Expected)
+		}
+	}
+}
+
+func TestMetadataToc(t *testing.T) {
+	t.Parallel()
+
+	meta := make(Metadata)
+	meta.Set("int_value", int64(-42))
+	meta.Set("bool_value", true)
+
+	expected := []string{"bool_value", "int_value"}
+
+	toc := meta.Toc()
+	if !reflect.DeepEqual(toc, expected) {
+		t.Errorf("%+v != %+v", toc, expected)
+	}
+}
+
+func TestMetadataCloneMerge(t *testing.T) {
+	t.Parallel()
+
+	orig := make(Metadata)
+	orig.Set("a", 42)
+	orig.Set("b", false)
+
+	additional := make(Metadata)
+	additional.Set("c", true)
+	additional.Set("b", 54)
+
+	new := orig.CloneMerge(additional)
+
+	expected := make(Metadata)
+	expected.Set("c", true)
+	expected.Set("b", 54)
+	expected.Set("a", 42)
+
+	if !reflect.DeepEqual(new, expected) {
+		t.Errorf("%+v != %+v", new, expected)
+	}
+
+	t.Run("with empty additional meta", func(t *testing.T) {
+		additional := make(Metadata)
+		new := orig.CloneMerge(additional)
+		if !reflect.DeepEqual(new, orig) {
+			t.Errorf("%+v != %+v", new, orig)
+		}
+	})
+}

--- a/format/putval_meta.go
+++ b/format/putval_meta.go
@@ -1,0 +1,53 @@
+// Package format provides utilities to format metrics and notifications in
+// various formats.
+package format // import "collectd.org/format"
+
+// Author: Remi Ferrand <remi.ferrand_at_cc.in2p3.fr>
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"collectd.org/api"
+)
+
+// PutvalWithMeta implements the Writer interface for PutvalWithMeta formatted output.
+// This format is not a standard format like PUTVAL is.
+// This formatter is currently only intended to help while developing plugins that support
+// metadata (LISTVAL or GETVAL does not currently display them)
+type PutvalWithMeta struct {
+	w io.Writer
+}
+
+// NewPutvalWithMeta returns a new PutvalWithMeta object writing to the provided io.Writer.
+func NewPutvalWithMeta(w io.Writer) *PutvalWithMeta {
+	return &PutvalWithMeta{
+		w: w,
+	}
+}
+
+// Write formats the ValueList in the PutvalWithMeta format and writes it to the
+// assiciated io.Writer.
+func (p *PutvalWithMeta) Write(_ context.Context, vl *api.ValueList) error {
+	s, err := formatValues(vl)
+	if err != nil {
+		return err
+	}
+
+	var metaStr string
+	if len(vl.Metadata) > 0 {
+		metaKeys := vl.Metadata.Toc()
+		metaPairs := make([]string, len(vl.Metadata))
+		for i, key := range metaKeys {
+			metaPairs[i] = fmt.Sprintf("%s=\"%s\"", key, vl.Metadata.GetAsString(key))
+		}
+
+		metaStr = " {" + strings.Join(metaPairs, ",") + "}"
+	}
+
+	_, err = fmt.Fprintf(p.w, "PUTVAL %q interval=%.3f %s%s\n",
+		vl.Identifier.String(), vl.Interval.Seconds(), s, metaStr)
+	return err
+}

--- a/plugin/c.go
+++ b/plugin/c.go
@@ -98,4 +98,84 @@ package plugin // import "collectd.org/plugin"
 //   return (*register_shutdown_ptr) (name, callback);
 //
 // }
+//
+// meta_data_t *(*meta_data_create_ptr) (void) = NULL;
+// meta_data_t *meta_data_create_wrapper(void) {
+//   if (meta_data_create_ptr == NULL) {
+//     void *hnd = dlopen(NULL, RTLD_LAZY);
+//     meta_data_create_ptr = dlsym(hnd, "meta_data_create");
+//     dlclose(hnd);
+//   }
+//   return (*meta_data_create_ptr)();
+// }
+//
+// meta_data_t *(*meta_data_destroy_ptr) (meta_data_t *meta) = NULL;
+// meta_data_t *meta_data_destroy_wrapper(meta_data_t *meta) {
+//   if (meta_data_destroy_ptr == NULL) {
+//     void *hnd = dlopen(NULL, RTLD_LAZY);
+//     meta_data_destroy_ptr = dlsym(hnd, "meta_data_destroy");
+//     dlclose(hnd);
+//   }
+//   return (*meta_data_destroy_ptr)(meta);
+// }
+//
+// int (*meta_data_add_string_ptr) (meta_data_t *md,
+//   const char *key, const char *value) = NULL;
+// int meta_data_add_string_wrapper(meta_data_t *md,
+//   const char *key, const char *value) {
+//     if (meta_data_add_string_ptr == NULL) {
+//       void *hnd = dlopen(NULL, RTLD_LAZY);
+//       meta_data_add_string_ptr = dlsym(hnd, "meta_data_add_string");
+//       dlclose(hnd);
+//     }
+//     return (*meta_data_add_string_ptr)(md, key, value);
+// }
+//
+// int (*meta_data_add_signed_int_ptr) (meta_data_t *md,
+//   const char *key, int64_t value) = NULL;
+// int meta_data_add_signed_int_wrapper(meta_data_t *md,
+//   const char *key, int64_t value) {
+//     if (meta_data_add_signed_int_ptr == NULL) {
+//       void *hnd = dlopen(NULL, RTLD_LAZY);
+//       meta_data_add_signed_int_ptr = dlsym(hnd, "meta_data_add_signed_int");
+//       dlclose(hnd);
+//     }
+//     return (*meta_data_add_signed_int_ptr)(md, key, value);
+// }
+//
+// int (*meta_data_add_unsigned_int_ptr) (meta_data_t *md,
+//   const char *key, uint64_t value) = NULL;
+// int meta_data_add_unsigned_int_wrapper(meta_data_t *md,
+//   const char *key, uint64_t value) {
+//     if (meta_data_add_unsigned_int_ptr == NULL) {
+//       void *hnd = dlopen(NULL, RTLD_LAZY);
+//       meta_data_add_unsigned_int_ptr = dlsym(hnd, "meta_data_add_unsigned_int");
+//       dlclose(hnd);
+//     }
+//     return (*meta_data_add_unsigned_int_ptr)(md, key, value);
+// }
+//
+// int (*meta_data_add_double_ptr) (meta_data_t *md,
+//   const char *key, double value) = NULL;
+// int meta_data_add_double_wrapper(meta_data_t *md,
+//   const char *key, double value) {
+//     if (meta_data_add_double_ptr == NULL) {
+//       void *hnd = dlopen(NULL, RTLD_LAZY);
+//       meta_data_add_double_ptr = dlsym(hnd, "meta_data_add_double");
+//       dlclose(hnd);
+//     }
+//     return (*meta_data_add_double_ptr)(md, key, value);
+// }
+//
+// int (*meta_data_add_boolean_ptr) (meta_data_t *md,
+//   const char *key, _Bool value) = NULL;
+// int meta_data_add_boolean_wrapper(meta_data_t *md,
+//   const char *key, _Bool value) {
+//     if (meta_data_add_boolean_ptr == NULL) {
+//       void *hnd = dlopen(NULL, RTLD_LAZY);
+//       meta_data_add_boolean_ptr = dlsym(hnd, "meta_data_add_boolean");
+//       dlclose(hnd);
+//     }
+//     return (*meta_data_add_boolean_ptr)(md, key, value);
+// }
 import "C"


### PR DESCRIPTION
This P.R aims to recreate a discussion about _ValueList metadatas_ and to eventually complete #34

When I've started this work, I didn't realize that #34 already existed, this is why you'll see that the `api.Metadata` type I've introduced is slightly different.
I do not have any problems dropping my implementation in favor of yours, as long as we finally get metadata support in the Go interface :wink:  

Here is an example of how to use the implementation this P.R introduces:

```go
meta := make(api.Metadata)
meta.Set("int_value", int64(-42))
meta.Set("bool_value", true)
meta.Set("str_value", "hello")
meta.Set("uint_value", uint64(42))
meta.Set("float_value", float64(42.0))
```

It also introduces a comprehensive set of metadata method that simplifies a _collectd plugin writer's life_.

```go
GetAsString(string) string
Exists(string) bool
Toc() []string
Clone() api.Metadata
CloneMerge(api.Metadata) api.Metadata
```

And finally, since metadatas are currently quite hard to preview (no `LISTVAL` or `GETVAL` support in my knowledge), this P.R also introduces a _formatter_ `format.PutvalWithMeta` that produces the following format to an `io.Writer`:

```
PUTVAL "/coredns-coredns_dns_request_size_bytes/counter-type_instance" interval=0.000 1573320191.161:24 {coredns.proto="udp",coredns.server="dns://:10053",coredns.zone=".",prom.bucket.upper_bound="8.29100e+03"}      
```

In this format, _metadatas_ are using _Prometheus like_ display format.