### PR TITLE
Package plugin: Fix memory allocation bug in value_list_add().

### DIFF
--- a/plugin/c.go
+++ b/plugin/c.go
@@ -35,8 +35,7 @@ package plugin // import "collectd.org/plugin"
 // }
 //
 // void value_list_add (value_list_t *vl, value_t v) {
-//   value_t *tmp;
-//   tmp = realloc (vl->values, (vl->values_len + 1));
+//   value_t *tmp = realloc (vl->values, sizeof(v) * (vl->values_len + 1));
 //   if (tmp == NULL) {
 //     errno = ENOMEM;
 //     return;


### PR DESCRIPTION
`value_list_add()` called `realloc(3)` with the number of _elements_ required, not the number of bytes. This caused a buffer overflow which only lead to a segfault with a sufficiently large number of data sources.

Fixes: #26