### PR TITLE
Package plugin: Free strings allocated in the register functions.

### DIFF
--- a/plugin/fake/log.go
+++ b/plugin/fake/log.go
@@ -45,6 +45,14 @@ package fake
 // }
 //
 // void reset_log(void) {
+//   for (size_t i = 0; i < log_callbacks_num; i++) {
+//     user_data_t *ud = &log_callbacks[i].user_data;
+//     if (ud->free_func == NULL) {
+//       continue;
+//     }
+//     ud->free_func(ud->data);
+//     ud->data = NULL;
+//   }
 //   free(log_callbacks);
 //   log_callbacks = NULL;
 //   log_callbacks_num = 0;

--- a/plugin/fake/read.go
+++ b/plugin/fake/read.go
@@ -55,6 +55,14 @@ package fake
 // }
 //
 // void reset_read(void) {
+//   for (size_t i = 0; i < read_callbacks_num; i++) {
+//     user_data_t *ud = &read_callbacks[i].user_data;
+//     if (ud->free_func == NULL) {
+//       continue;
+//     }
+//     ud->free_func(ud->data);
+//     ud->data = NULL;
+//   }
 //   free(read_callbacks);
 //   read_callbacks = NULL;
 //   read_callbacks_num = 0;

--- a/plugin/fake/write.go
+++ b/plugin/fake/write.go
@@ -70,6 +70,14 @@ package fake
 // }
 //
 // void reset_write(void) {
+//   for (size_t i = 0; i < write_callbacks_num; i++) {
+//     user_data_t *ud = &write_callbacks[i].user_data;
+//     if (ud->free_func == NULL) {
+//       continue;
+//     }
+//     ud->free_func(ud->data);
+//     ud->data = NULL;
+//   }
 //   free(write_callbacks);
 //   write_callbacks = NULL;
 //   write_callbacks_num = 0;

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -103,6 +103,8 @@ package plugin // import "collectd.org/plugin"
 //
 // int register_log_wrapper(char const *, plugin_log_cb, user_data_t const *);
 // int wrap_log_callback(int, char *, user_data_t *);
+//
+// typedef void (*free_func_t)(void *);
 import "C"
 
 import (
@@ -213,7 +215,7 @@ func RegisterRead(name string, r Reader) error {
 	cName := C.CString(name)
 	ud := C.user_data_t{
 		data:      unsafe.Pointer(cName),
-		free_func: nil,
+		free_func: C.free_func_t(C.free),
 	}
 
 	status, err := C.register_read_wrapper(cGroup, cName,
@@ -287,7 +289,7 @@ func RegisterWrite(name string, w api.Writer) error {
 	cName := C.CString(name)
 	ud := C.user_data_t{
 		data:      unsafe.Pointer(cName),
-		free_func: nil,
+		free_func: C.free_func_t(C.free),
 	}
 
 	status, err := C.register_write_wrapper(cName, C.plugin_write_cb(C.wrap_write_callback), &ud)
@@ -405,7 +407,7 @@ func RegisterLog(name string, l Logger) error {
 	cName := C.CString(name)
 	ud := C.user_data_t{
 		data:      unsafe.Pointer(cName),
-		free_func: nil,
+		free_func: C.free_func_t(C.free),
 	}
 
 	status, err := C.register_log_wrapper(cName, C.plugin_log_cb(C.wrap_log_callback), &ud)


### PR DESCRIPTION
These strings are actively used for the lifetime of the daemon, so it's not really a "leak", but not freeing these strings at shutdown is simply not good style.