### PR TITLE
Package exec: Add functional test, fix context cancellation.

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Putval is the dispatcher used by the exec package to print ValueLists.
-var Putval = format.NewPutval(os.Stdout)
+var Putval api.Writer = format.NewPutval(os.Stdout)
 
 type valueCallback struct {
 	callback func() api.Value
@@ -107,6 +107,9 @@ func (cb valueCallback) run(ctx context.Context, g *sync.WaitGroup) {
 		case _ = <-cb.done:
 			g.Done()
 			return
+		case <-ctx.Done():
+			g.Done()
+			return
 		}
 	}
 }
@@ -123,6 +126,9 @@ func (cb voidCallback) run(ctx context.Context, g *sync.WaitGroup) {
 		case _ = <-ticker.C:
 			cb.callback(ctx, cb.interval)
 		case _ = <-cb.done:
+			g.Done()
+			return
+		case <-ctx.Done():
 			g.Done()
 			return
 		}

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -17,18 +17,6 @@ import (
 // Putval is the dispatcher used by the exec package to print ValueLists.
 var Putval api.Writer = format.NewPutval(os.Stdout)
 
-type valueCallback struct {
-	callback func() api.Value
-	vl       *api.ValueList
-	done     chan bool
-}
-
-type voidCallback struct {
-	callback func(context.Context, time.Duration)
-	interval time.Duration
-	done     chan bool
-}
-
 type callback interface {
 	run(context.Context, *sync.WaitGroup)
 	stop()
@@ -51,10 +39,10 @@ func NewExecutor() *Executor {
 // only returns a Number, i.e. either a api.Gauge or api.Derive, and formatting
 // and printing is done by the executor.
 func (e *Executor) ValueCallback(callback func() api.Value, vl *api.ValueList) {
-	e.cb = append(e.cb, valueCallback{
+	e.cb = append(e.cb, &valueCallback{
 		callback: callback,
-		vl:       vl,
-		done:     make(chan bool),
+		vl:       *vl,
+		done:     make(chan struct{}),
 	})
 }
 
@@ -67,7 +55,7 @@ func (e *Executor) VoidCallback(callback func(context.Context, time.Duration), i
 	e.cb = append(e.cb, voidCallback{
 		callback: callback,
 		interval: interval,
-		done:     make(chan bool),
+		done:     make(chan struct{}),
 	})
 }
 
@@ -89,54 +77,64 @@ func (e *Executor) Stop() {
 	}
 }
 
-func (cb valueCallback) run(ctx context.Context, g *sync.WaitGroup) {
+type valueCallback struct {
+	callback func() api.Value
+	vl       api.ValueList
+	done     chan struct{}
+}
+
+func (cb *valueCallback) run(ctx context.Context, g *sync.WaitGroup) {
+	defer g.Done()
+
 	if cb.vl.Host == "" {
 		cb.vl.Host = Hostname()
 	}
 	cb.vl.Interval = sanitizeInterval(cb.vl.Interval)
-	cb.vl.Values = make([]api.Value, 1)
 
 	ticker := time.NewTicker(cb.vl.Interval)
-
 	for {
 		select {
-		case _ = <-ticker.C:
-			cb.vl.Values[0] = cb.callback()
+		case <-ticker.C:
+			cb.vl.Values = []api.Value{cb.callback()}
 			cb.vl.Time = time.Now()
-			Putval.Write(ctx, cb.vl)
-		case _ = <-cb.done:
-			g.Done()
+			Putval.Write(ctx, &cb.vl)
+		case <-cb.done:
 			return
 		case <-ctx.Done():
-			g.Done()
 			return
 		}
 	}
 }
 
-func (cb valueCallback) stop() {
-	cb.done <- true
+func (cb *valueCallback) stop() {
+	close(cb.done)
+}
+
+type voidCallback struct {
+	callback func(context.Context, time.Duration)
+	interval time.Duration
+	done     chan struct{}
 }
 
 func (cb voidCallback) run(ctx context.Context, g *sync.WaitGroup) {
+	defer g.Done()
+
 	ticker := time.NewTicker(sanitizeInterval(cb.interval))
 
 	for {
 		select {
-		case _ = <-ticker.C:
+		case <-ticker.C:
 			cb.callback(ctx, cb.interval)
-		case _ = <-cb.done:
-			g.Done()
+		case <-cb.done:
 			return
 		case <-ctx.Done():
-			g.Done()
 			return
 		}
 	}
 }
 
 func (cb voidCallback) stop() {
-	cb.done <- true
+	close(cb.done)
 }
 
 // Interval determines the default interval from the "COLLECTD_INTERVAL"

--- a/exec/exec_x_test.go
+++ b/exec/exec_x_test.go
@@ -1,0 +1,142 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"collectd.org/api"
+	"collectd.org/exec"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type testWriter struct {
+	vl *api.ValueList
+}
+
+func (w *testWriter) Write(_ context.Context, vl *api.ValueList) error {
+	if w.vl != nil {
+		return errors.New("received unexpected second value")
+	}
+
+	w.vl = vl
+	return nil
+}
+
+func TestValueCallback_ExecutorStop(t *testing.T) {
+	cases := []struct {
+		title    string
+		stopFunc func(f context.CancelFunc, e *exec.Executor)
+	}{
+		{"ExecutorStop", func(_ context.CancelFunc, e *exec.Executor) { e.Stop() }},
+		{"CancelContext", func(cancel context.CancelFunc, _ *exec.Executor) { cancel() }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if err := os.Setenv("COLLECTD_HOSTNAME", "example.com"); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				os.Unsetenv("COLLECTD_HOSTNAME")
+			}()
+
+			savedPutval := exec.Putval
+			defer func() {
+				exec.Putval = savedPutval
+			}()
+
+			w := &testWriter{}
+			exec.Putval = w
+
+			e := exec.NewExecutor()
+			ch := make(chan struct{})
+			go func() {
+				// wait for ch to be closed
+				<-ch
+				tc.stopFunc(cancel, e)
+			}()
+
+			e.ValueCallback(func() api.Value {
+				defer func() {
+					close(ch)
+				}()
+				return api.Derive(42)
+			}, &api.ValueList{
+				Identifier: api.Identifier{
+					Plugin: "go-exec",
+					Type:   "derive",
+				},
+				Interval: time.Millisecond,
+				DSNames:  []string{"value"},
+			})
+
+			// e.Run() blocks until the context is canceled or
+			// e.Stop() is called (see tc.stopFunc above).
+			e.Run(ctx)
+
+			want := &api.ValueList{
+				Identifier: api.Identifier{
+					Host:   "example.com",
+					Plugin: "go-exec",
+					Type:   "derive",
+				},
+				Interval: time.Millisecond,
+				Values:   []api.Value{api.Derive(42)},
+				DSNames:  []string{"value"},
+			}
+			if diff := cmp.Diff(want, w.vl, cmpopts.IgnoreFields(api.ValueList{}, "Time")); diff != "" {
+				t.Errorf("received value lists differ (+got/-want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestVoidCallback(t *testing.T) {
+	cases := []struct {
+		title    string
+		stopFunc func(f context.CancelFunc, e *exec.Executor)
+	}{
+		{"ExecutorStop", func(_ context.CancelFunc, e *exec.Executor) { e.Stop() }},
+		{"CancelContext", func(cancel context.CancelFunc, _ *exec.Executor) { cancel() }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			e := exec.NewExecutor()
+			ch := make(chan struct{})
+			go func() {
+				// wait for ch to be closed
+				<-ch
+				tc.stopFunc(cancel, e)
+			}()
+
+			var calls int
+			e.VoidCallback(func(_ context.Context, d time.Duration) {
+				if got, want := d, time.Millisecond; got != want {
+					t.Errorf("VoidCallback(%v), want argument %v", got, want)
+				}
+				calls++
+
+				close(ch)
+			}, time.Millisecond)
+
+			// e.Run() blocks until the context is canceled or
+			// e.Stop() is called (see tc.stopFunc above).
+			e.Run(ctx)
+
+			if got, want := calls, 1; got != want {
+				t.Errorf("number of calls = %d, want %d", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds two tests, one for "void" and one for "value" callbacks. The tests are implemented in an external package and don't have access to "exec"'s private types and fields.
    
This change also adds the code required to return from `Executor.Run()` when the context is canceled.
