### PR TITLE
Package plugin: Set a timeout on the context passed to read callbacks.

### DIFF
--- a/plugin/c.go
+++ b/plugin/c.go
@@ -117,4 +117,14 @@ package plugin // import "collectd.org/plugin"
 //   }
 //   return (*register_log_ptr) (name, callback, user_data);
 // }
+//
+// static int *timeout_ptr;
+// int timeout_wrapper(void) {
+//   if (timeout_ptr == NULL) {
+//     void *hnd = dlopen(NULL, RTLD_LAZY);
+//     timeout_ptr = dlsym(hnd, "timeout_g");
+//     dlclose(hnd);
+//   }
+//   return *timeout_ptr;
+// }
 import "C"

--- a/plugin/fake/fake.go
+++ b/plugin/fake/fake.go
@@ -6,6 +6,8 @@ package fake
 // void reset_read(void);
 // void reset_shutdown(void);
 // void reset_write(void);
+//
+// int timeout_g = 2;
 import "C"
 
 import (

--- a/plugin/fake/read.go
+++ b/plugin/fake/read.go
@@ -18,6 +18,10 @@ package fake
 // int plugin_register_complex_read(const char *group, const char *name,
 //                                  plugin_read_cb callback, cdtime_t interval,
 //                                  user_data_t const *user_data) {
+//   if (interval == 0) {
+//     interval = plugin_get_interval();
+//   }
+//
 //   read_callback_t *ptr = realloc(
 //       read_callbacks, (read_callbacks_num + 1) * sizeof(*read_callbacks));
 //   if (ptr == NULL) {


### PR DESCRIPTION
I considered, and had already implemented, a `WithoutTimeout` option that could be passed to `RegisterRead`. My idea was to provide plugins with a long-lived context, in case they need to establish connections or the like. However, it turns out that all examples I looked at, e.g. `"net".Dialer.DialContext` and `"google.golang.org/grpc".DialContext` return connections which are not affected by the context's cancellation. So I decided to keep the API simple and add a `WithoutTimeout` option if and when somebody comes up with a use case.