### PR TITLE
Package export: Add support for context cancellation and add tests.

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -89,8 +89,7 @@ func Run(ctx context.Context, w api.Writer, opts Options) error {
 				vl.Time = time.Now()
 				vl.Interval = opts.Interval
 				if err := w.Write(ctx, vl); err != nil {
-					mutex.RUnlock()
-					return err
+					log.Printf("%T.Write(): %v", w, err)
 				}
 			}
 			mutex.RUnlock()

--- a/export/export.go
+++ b/export/export.go
@@ -19,13 +19,16 @@ Gauge.
 
   // Call Run() in its own goroutine.
   func main() {
+          ctx := context.Background()
+
+          // Any other type implementing api.Writer works.
           client, err := network.Dial(
                   net.JoinHostPort(network.DefaultIPv6Address, network.DefaultService),
                   network.ClientOptions{})
           if err !=  nil {
                   log.Fatal(err)
-                  }
-          go export.Run(client, export.Options{
+          }
+          go export.Run(ctx, client, export.Options{
                   Interval: 10 * time.Second,
           })
           // …

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -1,20 +1,25 @@
 package export // import "collectd.org/export"
 
 import (
+	"context"
+	"errors"
 	"expvar"
-	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"collectd.org/api"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestDerive(t *testing.T) {
-	d := NewDerive(api.Identifier{
-		Host:   "example.com",
-		Plugin: "golang",
-		Type:   "derive",
-	})
+	// clean up shared resource after testing
+	defer func() {
+		vars = nil
+	}()
 
+	d := NewDeriveString("example.com/TestDerive/derive")
 	for i := 0; i < 10; i++ {
 		d.Add(i)
 	}
@@ -22,48 +27,136 @@ func TestDerive(t *testing.T) {
 	want := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:   "example.com",
-			Plugin: "golang",
+			Plugin: "TestDerive",
 			Type:   "derive",
 		},
 		Values: []api.Value{api.Derive(45)},
 	}
 	got := d.ValueList()
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %#v, want %#v", got, want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Derive.ValueList() differs (+got/-want):\n%s", diff)
 	}
 
-	s := expvar.Get("example.com/golang/derive").String()
+	s := expvar.Get("example.com/TestDerive/derive").String()
 	if s != "45" {
 		t.Errorf("got %q, want %q", s, "45")
 	}
 }
 
 func TestGauge(t *testing.T) {
-	g := NewGauge(api.Identifier{
-		Host:   "example.com",
-		Plugin: "golang",
-		Type:   "gauge",
-	})
+	// clean up shared resource after testing
+	defer func() {
+		vars = nil
+	}()
 
+	g := NewGaugeString("example.com/TestGauge/gauge")
 	g.Set(42.0)
 
 	want := &api.ValueList{
 		Identifier: api.Identifier{
 			Host:   "example.com",
-			Plugin: "golang",
+			Plugin: "TestGauge",
 			Type:   "gauge",
 		},
 		Values: []api.Value{api.Gauge(42)},
 	}
 	got := g.ValueList()
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %#v, want %#v", got, want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Gauge.ValueList() differs (+got/-want):\n%s", diff)
 	}
 
-	s := expvar.Get("example.com/golang/gauge").String()
+	s := expvar.Get("example.com/TestGauge/gauge").String()
 	if s != "42" {
 		t.Errorf("got %q, want %q", s, "42")
+	}
+}
+
+type testWriter struct {
+	got  []*api.ValueList
+	done chan<- struct{}
+	once *sync.Once
+}
+
+func (w *testWriter) Write(ctx context.Context, vl *api.ValueList) error {
+	w.got = append(w.got, vl)
+	w.once.Do(func() {
+		close(w.done)
+	})
+	return nil
+}
+
+func TestRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// clean up shared resource after testing
+	defer func() {
+		vars = nil
+	}()
+
+	d := NewDeriveString("example.com/TestRun/derive")
+	d.Add(23)
+
+	g := NewGaugeString("example.com/TestRun/gauge")
+	g.Set(42)
+
+	var (
+		done = make(chan struct{})
+		once sync.Once
+	)
+
+	w := testWriter{
+		done: done,
+		once: &once,
+	}
+
+	go func() {
+		// when one metric has been written, cancel the context
+		<-done
+		cancel()
+	}()
+
+	err := Run(ctx, &w, Options{Interval: 100 * time.Millisecond})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Run() = %v, want %v", err, context.Canceled)
+	}
+
+	want := []*api.ValueList{
+		{
+			Identifier: api.Identifier{
+				Host:   "example.com",
+				Plugin: "TestRun",
+				Type:   "gauge",
+			},
+			Time:     time.Now(),
+			Interval: 100 * time.Millisecond,
+			Values:   []api.Value{api.Gauge(42)},
+		},
+		{
+			Identifier: api.Identifier{
+				Host:   "example.com",
+				Plugin: "TestRun",
+				Type:   "derive",
+			},
+			Time:     time.Now(),
+			Interval: 100 * time.Millisecond,
+			Values:   []api.Value{api.Derive(23)},
+		},
+	}
+
+	ignoreOrder := cmpopts.SortSlices(func(a, b *api.ValueList) bool {
+		return a.Identifier.String() < b.Identifier.String()
+	})
+	approximateTime := cmp.Comparer(func(t0, t1 time.Time) bool {
+		diff := t0.Sub(t1)
+		if t1.After(t0) {
+			diff = t1.Sub(t0)
+		}
+
+		return diff < 2*time.Second
+	})
+	if diff := cmp.Diff(want, w.got, ignoreOrder, approximateTime); diff != "" {
+		t.Errorf("received value lists differ (+got/-want):\n%s", diff)
 	}
 }


### PR DESCRIPTION
The `Run()` function previously didn't return, even if the context got cancelled. This was not the correct behavior.

Previously, the `Run()` function did return if any `Write()` failed, which was not documented and not the intended behavior. This has been changed to a log statement instead.

Testing of the `export` package has been improved. It now also tests the `Run()` function.