### PR TITLE
Package plugin: Remove the Writer type.

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -172,16 +172,10 @@ func newValueListT(vl *api.ValueList) (*C.value_list_t, error) {
 	return ret, nil
 }
 
-// Writer implements the api.Write interface.
-type Writer struct{}
-
-// Write implements the api.Writer interface for the collectd daemon.
-func (Writer) Write(ctx context.Context, vl *api.ValueList) error {
-	return Write(ctx, vl)
-}
-
 // Write converts a ValueList and calls the plugin_dispatch_values() function
 // of the collectd daemon.
+//
+// Use api.WriterFunc to pass this function as an api.Writer.
 func Write(ctx context.Context, vl *api.ValueList) error {
 	select {
 	case <-ctx.Done():

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -230,8 +230,7 @@ func (r *testReader) Read(ctx context.Context) error {
 		return r.wantErr
 	}
 
-	w := plugin.Writer{}
-	return w.Write(ctx, r.vl)
+	return plugin.Write(ctx, r.vl)
 }
 
 type testWriter struct {


### PR DESCRIPTION
Use `api.WriterFunc` instead.