### PR TITLE
Package plugin: Automatically determine ValueList.Identifier.Plugin if empty.

### DIFF
--- a/cdtime/cdtime.go
+++ b/cdtime/cdtime.go
@@ -14,6 +14,9 @@ type Time uint64
 
 // New returns a new Time representing time t.
 func New(t time.Time) Time {
+	if t.IsZero() {
+		return 0
+	}
 	return newNano(uint64(t.UnixNano()))
 }
 

--- a/cdtime/cdtime_test.go
+++ b/cdtime/cdtime_test.go
@@ -8,9 +8,9 @@ import (
 	"collectd.org/cdtime"
 )
 
-// TestConversion converts a time.Time to a cdtime.Time and back, expecting the
+// TestNew converts a time.Time to a cdtime.Time and back, expecting the
 // original time.Time back.
-func TestConversion(t *testing.T) {
+func TestNew(t *testing.T) {
 	cases := []string{
 		"2009-02-04T21:00:57-08:00",
 		"2009-02-04T21:00:57.1-08:00",
@@ -36,6 +36,16 @@ func TestConversion(t *testing.T) {
 		if !got.Equal(want) {
 			t.Errorf("cdtime.Time(): got %v, want %v", got, want)
 		}
+	}
+}
+
+func TestNew_zero(t *testing.T) {
+	var (
+		got  = cdtime.New(time.Time{})
+		want = cdtime.Time(0)
+	)
+	if got != want {
+		t.Errorf("cdtime.New(time.Time{}) = %v, want %v", got, want)
 	}
 }
 
@@ -73,6 +83,7 @@ func TestNewDuration(t *testing.T) {
 		{1439981880053705608 * time.Nanosecond, cdtime.Time(1546168770415815077)},
 		// 1439981880053705920 * 2^30 / 10^9 = 1546168770415815412.5
 		{1439981880053705920 * time.Nanosecond, cdtime.Time(1546168770415815413)},
+		{0, 0},
 	}
 
 	for _, tc := range cases {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -116,14 +116,14 @@ func TestReadWrite(t *testing.T) {
 			title: "derive",
 			modifyVL: func(vl *api.ValueList) {
 				vl.Type = "derive"
-				vl.Values[0] = api.Derive(42)
+				vl.Values = []api.Value{api.Derive(42)}
 			},
 		},
 		{
 			title: "counter",
 			modifyVL: func(vl *api.ValueList) {
 				vl.Type = "counter"
-				vl.Values[0] = api.Counter(42)
+				vl.Values = []api.Value{api.Counter(42)}
 			},
 		},
 		{
@@ -164,13 +164,13 @@ func TestReadWrite(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			defer fake.TearDown()
 
-			vl := baseVL
+			vl := baseVL.Clone()
 			if tc.modifyVL != nil {
-				tc.modifyVL(&vl)
+				tc.modifyVL(vl)
 			}
 
 			r := &testReader{
-				vl:       &vl,
+				vl:       vl,
 				wantName: "TestRead",
 				wantErr:  tc.readErr,
 			}
@@ -201,7 +201,7 @@ func TestReadWrite(t *testing.T) {
 				t.FailNow()
 			}
 
-			if got, want := w.valueLists[0], &vl; !cmp.Equal(got, want) {
+			if got, want := w.valueLists[0], vl; !cmp.Equal(got, want) {
 				t.Errorf("ValueList differs (-want/+got): %s", cmp.Diff(want, got))
 			}
 		})

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -158,6 +158,12 @@ func TestReadWrite(t *testing.T) {
 			writeErr: errors.New("write error"),
 			wantErr:  true,
 		},
+		{
+			title: "plugin name is filled in",
+			modifyVL: func(vl *api.ValueList) {
+				vl.Plugin = ""
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -199,6 +205,11 @@ func TestReadWrite(t *testing.T) {
 			}
 			if len(w.valueLists) < 1 {
 				t.FailNow()
+			}
+
+			// Expect vl.Plugin to get populated.
+			if vl.Plugin == "" {
+				vl.Plugin = "TestRead"
 			}
 
 			if got, want := w.valueLists[0], vl; !cmp.Equal(got, want) {


### PR DESCRIPTION
This PR also improves the documentation around which fields are automatically populated if empty. A corner case in `cdtime.New()` has been fixed and a bug in the `plugin_test` has been fixed.