### PR TITLE
Package plugin: Add the LogWriter type.

### DIFF
--- a/plugin/log.go
+++ b/plugin/log.go
@@ -21,6 +21,8 @@ import "C"
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
 	"unsafe"
 )
 
@@ -39,11 +41,14 @@ const (
 )
 
 func log(s Severity, msg string) error {
+	// Trim trailing whitespace.
+	msg = strings.TrimRightFunc(msg, unicode.IsSpace)
+
 	ptr := C.CString(msg)
 	defer C.free(unsafe.Pointer(ptr))
 
 	_, err := C.wrap_plugin_log(C.int(s), ptr)
-	return err
+	return wrapCError(0, err, "plugin_log")
 }
 
 // Error logs an error using plugin_log(). Arguments are handled in the manner

--- a/plugin/log.go
+++ b/plugin/log.go
@@ -110,3 +110,14 @@ func Debug(v ...interface{}) error {
 func Debugf(format string, v ...interface{}) error {
 	return Debug(fmt.Sprintf(format, v...))
 }
+
+// LogWriter implements the io.Writer interface on top of collectd's logging facility.
+type LogWriter Severity
+
+// Write converts p to a string and logs it with w's severity.
+func (w LogWriter) Write(p []byte) (n int, err error) {
+	if err := log(Severity(w), string(p)); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/plugin/log_test.go
+++ b/plugin/log_test.go
@@ -1,0 +1,21 @@
+package plugin_test
+
+import (
+	"errors"
+	"log"
+	"net/http"
+
+	"collectd.org/plugin"
+)
+
+func ExampleLogWriter() {
+	l := log.New(plugin.LogWriter(plugin.SeverityError), "", log.Lshortfile)
+
+	// Start an HTTP server that logs errors to collectd's logging facility.
+	srv := &http.Server{
+		ErrorLog: l,
+	}
+	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		l.Println("ListenAndServe:", err)
+	}
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -42,6 +42,10 @@ func (l *testLogger) Log(ctx context.Context, s plugin.Severity, msg string) {
 	l.Name, _ = plugin.Name(ctx)
 }
 
+func (l *testLogger) reset() {
+	*l = testLogger{}
+}
+
 func TestLog(t *testing.T) {
 	cases := []struct {
 		title    string
@@ -77,7 +81,7 @@ func TestLog(t *testing.T) {
 				t.Errorf("Message = %q, want %q", got, want)
 			}
 
-			*l = testLogger{}
+			l.reset()
 			tc.fmtFunc("test %d %%s", 42)
 			if got, want := l.Name, name; got != want {
 				t.Errorf("plugin.Name() = %q, want %q", got, want)
@@ -86,6 +90,18 @@ func TestLog(t *testing.T) {
 				t.Errorf("Severity = %v, want %v", got, want)
 			}
 			if got, want := l.Message, "test 42 %s"; got != want {
+				t.Errorf("Message = %q, want %q", got, want)
+			}
+
+			l.reset()
+			fmt.Fprintln(plugin.LogWriter(tc.severity), "test message:", 42)
+			if got, want := l.Name, name; got != want {
+				t.Errorf("plugin.Name() = %q, want %q", got, want)
+			}
+			if got, want := l.Severity, tc.severity; got != want {
+				t.Errorf("Severity = %v, want %v", got, want)
+			}
+			if got, want := l.Message, "test message: 42"; got != want {
 				t.Errorf("Message = %q, want %q", got, want)
 			}
 		})


### PR DESCRIPTION
`LogWriter` implements the `io.Writer` interface on top of collectd's logging infrastructure. This allows, for example, to create a `log.Logger` writing to the collectd log.