### PR TITLE
Package config: Drop the "Value" suffix from "{Bool,Float64,String}Value".

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,11 +19,11 @@ In Go, this would be represented as:
 
 	Block{
 		Key: "Key",
-		Values: []Value{StringValue("Value")},
+		Values: []Value{String("Value")},
 		Children: []Block{
 			{
 				Key: "Child",
-				Values: []Value{StringValue("child value")},
+				Values: []Value{String("child value")},
 			},
 		},
 	}
@@ -62,14 +62,14 @@ type Value struct {
 	b   bool
 }
 
-// StringValue returns a new string Value.
-func StringValue(v string) Value { return Value{typ: stringType, s: v} }
+// String returns a new string Value.
+func String(v string) Value { return Value{typ: stringType, s: v} }
 
-// Float64Value returns a new float64 Value.
-func Float64Value(v float64) Value { return Value{typ: numberType, f: v} }
+// Float64 returns a new float64 Value.
+func Float64(v float64) Value { return Value{typ: numberType, f: v} }
 
-// BoolValue returns a new bool Value.
-func BoolValue(v bool) Value { return Value{typ: booleanType, b: v} }
+// Bool returns a new bool Value.
+func Bool(v bool) Value { return Value{typ: booleanType, b: v} }
 
 // Values allocates and initializes a []Value slice. "string", "float64", and
 // "bool" are mapped directly. "[]byte" is converted to a string. Numeric types
@@ -79,20 +79,20 @@ func Values(values ...interface{}) []Value {
 	var ret []Value
 	for _, v := range values {
 		if v == nil {
-			ret = append(ret, Float64Value(math.NaN()))
+			ret = append(ret, Float64(math.NaN()))
 			continue
 		}
 
 		// check for exact matches first.
 		switch v := v.(type) {
 		case string:
-			ret = append(ret, StringValue(v))
+			ret = append(ret, String(v))
 			continue
 		case []byte:
-			ret = append(ret, StringValue(string(v)))
+			ret = append(ret, String(string(v)))
 			continue
 		case bool:
-			ret = append(ret, BoolValue(v))
+			ret = append(ret, Bool(v))
 			continue
 		}
 
@@ -103,12 +103,12 @@ func Values(values ...interface{}) []Value {
 		)
 		if valueType.ConvertibleTo(float64Type) {
 			v := reflect.ValueOf(v).Convert(float64Type).Interface().(float64)
-			ret = append(ret, Float64Value(v))
+			ret = append(ret, Float64(v))
 			continue
 		}
 
 		// Last resort: convert to a string using the "fmt" package:
-		ret = append(ret, StringValue(fmt.Sprintf("%v", v)))
+		ret = append(ret, String(fmt.Sprintf("%v", v)))
 	}
 	return ret
 }
@@ -117,11 +117,11 @@ func Values(values ...interface{}) []Value {
 func (cv Value) GoString() string {
 	switch cv.typ {
 	case stringType:
-		return fmt.Sprintf("config.StringValue(%q)", cv.s)
+		return fmt.Sprintf("config.String(%q)", cv.s)
 	case numberType:
-		return fmt.Sprintf("config.Float64Value(%v)", cv.f)
+		return fmt.Sprintf("config.Float64(%v)", cv.f)
 	case booleanType:
-		return fmt.Sprintf("config.BoolValue(%v)", cv.b)
+		return fmt.Sprintf("config.Bool(%v)", cv.b)
 	}
 	return "<invalid config.Value>"
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -322,11 +322,11 @@ func TestConfig_Unmarshal(t *testing.T) {
 			name: "port numeric success",
 			src: Block{
 				Key:    "Plugin",
-				Values: []Value{StringValue("test")},
+				Values: []Value{String("test")},
 				Children: []Block{
 					{
 						Key:    "Port",
-						Values: []Value{Float64Value(80)},
+						Values: []Value{Float64(80)},
 					},
 				},
 			},
@@ -346,11 +346,11 @@ func TestConfig_Unmarshal(t *testing.T) {
 			name: "port out of range",
 			src: Block{
 				Key:    "Plugin",
-				Values: []Value{StringValue("test")},
+				Values: []Value{String("test")},
 				Children: []Block{
 					{
 						Key:    "Port",
-						Values: []Value{Float64Value(1 << 48)},
+						Values: []Value{Float64(1 << 48)},
 					},
 				},
 			},
@@ -364,11 +364,11 @@ func TestConfig_Unmarshal(t *testing.T) {
 			name: "port not a number",
 			src: Block{
 				Key:    "Plugin",
-				Values: []Value{StringValue("test")},
+				Values: []Value{String("test")},
 				Children: []Block{
 					{
 						Key:    "Port",
-						Values: []Value{Float64Value(math.NaN())},
+						Values: []Value{Float64(math.NaN())},
 					},
 				},
 			},
@@ -382,11 +382,11 @@ func TestConfig_Unmarshal(t *testing.T) {
 			name: "port invalid type",
 			src: Block{
 				Key:    "Plugin",
-				Values: []Value{StringValue("test")},
+				Values: []Value{String("test")},
 				Children: []Block{
 					{
 						Key:    "Port",
-						Values: []Value{BoolValue(true)},
+						Values: []Value{Bool(true)},
 					},
 				},
 			},
@@ -400,11 +400,11 @@ func TestConfig_Unmarshal(t *testing.T) {
 			name: "port string success",
 			src: Block{
 				Key:    "Plugin",
-				Values: []Value{StringValue("test")},
+				Values: []Value{String("test")},
 				Children: []Block{
 					{
 						Key:    "Port",
-						Values: []Value{StringValue("http")},
+						Values: []Value{String("http")},
 					},
 				},
 			},
@@ -424,11 +424,11 @@ func TestConfig_Unmarshal(t *testing.T) {
 			name: "port string failure",
 			src: Block{
 				Key:    "Plugin",
-				Values: []Value{StringValue("test")},
+				Values: []Value{String("test")},
 				Children: []Block{
 					{
 						Key:    "Port",
-						Values: []Value{StringValue("--- invalid ---")},
+						Values: []Value{String("--- invalid ---")},
 					},
 				},
 			},
@@ -460,20 +460,20 @@ func TestValues(t *testing.T) {
 		want Value
 	}{
 		// exact matches
-		{nil, Float64Value(math.NaN())},
-		{"foo", StringValue("foo")},
-		{[]byte("byte array"), StringValue("byte array")},
-		{true, BoolValue(true)},
-		{float64(42.11), Float64Value(42.11)},
+		{nil, Float64(math.NaN())},
+		{"foo", String("foo")},
+		{[]byte("byte array"), String("byte array")},
+		{true, Bool(true)},
+		{float64(42.11), Float64(42.11)},
 		// convertible to float64
-		{float32(12.25), Float64Value(12.25)},
-		{int(0x1F622), Float64Value(128546)},
-		{uint64(0x1F61F), Float64Value(128543)},
+		{float32(12.25), Float64(12.25)},
+		{int(0x1F622), Float64(128546)},
+		{uint64(0x1F61F), Float64(128543)},
 		// not convertiable to float64
-		{complex(4, 1), StringValue("(4+1i)")},
-		{struct{}{}, StringValue("{}")},
-		{map[string]int{"answer": 42}, StringValue("map[answer:42]")},
-		{[]int{1, 2, 3}, StringValue("[1 2 3]")},
+		{complex(4, 1), String("(4+1i)")},
+		{struct{}{}, String("{}")},
+		{map[string]int{"answer": 42}, String("map[answer:42]")},
+		{[]int{1, 2, 3}, String("[1 2 3]")},
 	}
 
 	opts := []cmp.Option{
@@ -495,9 +495,9 @@ func TestValue_Interface(t *testing.T) {
 		v    Value
 		want interface{}
 	}{
-		{StringValue("foo"), "foo"},
-		{Float64Value(42.0), 42.0},
-		{BoolValue(true), true},
+		{String("foo"), "foo"},
+		{Float64(42.0), 42.0},
+		{Bool(true), true},
 		{Value{}, ""}, // zero value is a string
 	}
 

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -106,19 +106,19 @@ func unmarshalConfigValue(value *C.oconfig_value_t) (config.Value, error) {
 		if err := wrapCError(0, err, "config_value_string"); err != nil {
 			return config.Value{}, err
 		}
-		return config.StringValue(C.GoString(s)), nil
+		return config.String(C.GoString(s)), nil
 	case C.OCONFIG_TYPE_NUMBER:
 		n, err := C.config_value_number(value)
 		if err := wrapCError(0, err, "config_value_number"); err != nil {
 			return config.Value{}, err
 		}
-		return config.Float64Value(float64(n)), nil
+		return config.Float64(float64(n)), nil
 	case C.OCONFIG_TYPE_BOOLEAN:
 		b, err := C.config_value_boolean(value)
 		if err := wrapCError(0, err, "config_value_boolean"); err != nil {
 			return config.Value{}, err
 		}
-		return config.BoolValue(bool(b)), nil
+		return config.Bool(bool(b)), nil
 	default:
 		return config.Value{}, fmt.Errorf("unknown config value type: %d", typ)
 	}


### PR DESCRIPTION
This reduces differences between the `config` and the `meta` package, avoiding unnecessary cognitive load.