### PR TITLE
Update network function to use a single dispatcher and buffered channel

### DIFF
--- a/network/crypto.go
+++ b/network/crypto.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -32,8 +31,8 @@ type PasswordLookup interface {
 // The file has a very simple syntax with one username / password mapping per
 // line, separated by a colon. For example:
 //
-//   alice: w0nderl4nd
-//   bob:   bu1|der
+//	alice: w0nderl4nd
+//	bob:   bu1|der
 type AuthFile struct {
 	name string
 	last time.Time
@@ -178,7 +177,6 @@ func createCipher(password string, iv []byte) (cipher.Stream, error) {
 func encryptAES256(plaintext []byte, username, password string) ([]byte, error) {
 	iv := make([]byte, 16)
 	if _, err := rand.Read(iv); err != nil {
-		log.Printf("rand.Read: %v", err)
 		return nil, err
 	}
 

--- a/network/fuzz.go
+++ b/network/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package network // import "collectd.org/network"

--- a/network/fuzz_test.go
+++ b/network/fuzz_test.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package network // import "collectd.org/network"

--- a/network/main.go
+++ b/network/main.go
@@ -13,8 +13,15 @@ const (
 
 // DefaultBufferSize is the default size of "Buffer". This is based on the
 // maximum bytes that fit into an Ethernet frame without fragmentation:
-//   <Ethernet frame> - (<IPv6 header> + <UDP header>) = 1500 - (40 + 8) = 1452
+//
+//	<Ethernet frame> - (<IPv6 header> + <UDP header>) = 1500 - (40 + 8) = 1452
 const DefaultBufferSize = 1452
+
+// DefaultDispatcherBufferSize is the default depth on the dispatcher channel which
+// asynchronously reades value sets from the main server Listener loop and writes them into the api.Writer
+// This allows high throughput and asynchronous writes without creating the situation where an api.Writer
+// that blocks can cause an infinite buildup go in flight messages and eventual OOM.
+const DefaultDispatcherBufferSize = 1024
 
 // Numeric data source type identifiers.
 const (

--- a/network/main.go
+++ b/network/main.go
@@ -18,7 +18,7 @@ const (
 const DefaultBufferSize = 1452
 
 // DefaultDispatcherBufferSize is the default depth on the dispatcher channel which
-// asynchronously reades value sets from the main server Listener loop and writes them into the api.Writer
+// asynchronously reads value sets from the main server Listener loop and writes them into the api.Writer
 // This allows high throughput and asynchronous writes without creating the situation where an api.Writer
 // that blocks can cause an infinite buildup go in flight messages and eventual OOM.
 const DefaultDispatcherBufferSize = 1024

--- a/network/network_x_test.go
+++ b/network/network_x_test.go
@@ -69,7 +69,8 @@ func TestNetwork(t *testing.T) {
 				Password:      password,
 			})
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		vl := &api.ValueList{


### PR DESCRIPTION
This PR does two things:

1. Change the main Listen routine to use a single go routine with a buffered channel so that a blocked api.Writer won't build up an unlimited number of go routines eventually exhausting the stack and OOMing the process
2. Added an optional log.Logger member to the server so that the library isn't just spitting error messages at stdout.  If the logger is not specified the old behavior is maintained.


Some additional context:
RE point 1.   We have found that when using the library and the current method of kicking off a go routine for every message is susceptible to stack and memory exhaustion if the api.Writer blocks for any reason.  I believe that a buffered channel is a better methodology as it will eventually just block and stop consuming stack and memory space if the api.Writer cannot service the messages.


RE point 2.  Errors in parsing are currently just tossed to stdout with no way for a caller to capture or route them.  This just provides the option for a caller to hand in a log.Logger and route/capture those errors.